### PR TITLE
Signal Weave: 2-6 operators, evolving target, sync tiers

### DIFF
--- a/src/lib/games/signal-weave/main.ts
+++ b/src/lib/games/signal-weave/main.ts
@@ -3,23 +3,84 @@ import type { DataConnection } from "peerjs";
 import { createGameLoop } from "$lib/game-loop";
 import { describePeerError, makeCode } from "$lib/peer";
 
+// ── Tuning ─────────────────────────────────────────────────────────────────────
+
 const PEER_PREFIX = "sigweave-";
-const MAX_PLAYERS = 2;
-const PULSE_X_MIN = 0.2;
-const PULSE_X_SPAN = 0.6;
+const MAX_PLAYERS = 6;
+const MIN_PLAYERS = 2;
+const ROOM_CODE_LENGTH = 5;
+
 const NETWORK_TICK_RATE = 0.05;
-const COMBO_TIMEOUT_SECONDS = 4;
-const PULSE_SYNC_WINDOW_SECONDS = 0.8;
+const ROUND_DURATION = 90;
+
 export const OFFSET_MIN = 0;
-export const OFFSET_MAX = 628;
+export const OFFSET_MAX = 628; // 0..2π * 100, scaled for the integer slider
 const OFFSET_SCALE = 100;
 const ARROW_KEY_STEP = 6;
-const ROOM_CODE_LENGTH = 5;
+
+const PULSE_SYNC_WINDOW_SECONDS = 0.85;
+const COMBO_TIMEOUT_SECONDS = 4;
 const HARMONY_THRESHOLD = 0.18;
 const HARMONY_GAIN_RATE = 12;
+const PULSE_X_MIN = 0.2;
+const PULSE_X_SPAN = 0.6;
 
-type Pulse = { owner: number; t: number; good: boolean };
-type GameSnapshot = {
+// Each operator slot owns one sine component of the combined signal.
+// Frequencies are picked to interleave nicely; colors match the lobby roster.
+interface SineComponent {
+  freq: number;
+  color: string;
+  label: string;
+}
+const FALLBACK_COMPONENT: SineComponent = { freq: 2.0, color: "#79f3ff", label: "TURQ" };
+const COMPONENTS: ReadonlyArray<SineComponent> = [
+  FALLBACK_COMPONENT,
+  { freq: 2.7, color: "#ff7ccf", label: "ROSE" },
+  { freq: 3.4, color: "#8dff9d", label: "MINT" },
+  { freq: 1.6, color: "#ffb36b", label: "AMBR" },
+  { freq: 4.1, color: "#a06bff", label: "VIOL" },
+  { freq: 2.3, color: "#ffdd00", label: "SOLA" },
+];
+
+function componentFor(slot: number): SineComponent {
+  return COMPONENTS[slot] ?? FALLBACK_COMPONENT;
+}
+
+// Target evolves through three "movements" so the round doesn't feel static.
+type TargetMode = "drift" | "double" | "tempest";
+const MODE_PALETTE: Record<TargetMode, string> = {
+  drift: "#ff7ccf",
+  double: "#ff5acd",
+  tempest: "#ff3aa1",
+};
+const MODE_LABEL: Record<TargetMode, string> = {
+  drift: "MOV. I — DRIFT",
+  double: "MOV. II — DOUBLE",
+  tempest: "MOV. III — TEMPEST",
+};
+
+function modeAt(t: number): TargetMode {
+  const phase = Math.floor(t / 25) % 3;
+  return phase === 0 ? "drift" : phase === 1 ? "double" : "tempest";
+}
+
+function targetValue(t: number): number {
+  const mode = modeAt(t);
+  if (mode === "drift") {
+    return Math.sin(t * 1.5 + Math.sin(t * 0.4) * 1.2);
+  }
+  if (mode === "double") {
+    // Two-frequency target with a slow sweep
+    return (Math.sin(t * 1.8) + Math.sin(t * 1.05 + 0.6)) * 0.5;
+  }
+  // tempest: faster, modulated
+  return Math.sin(t * 2.4 + Math.sin(t * 0.9) * 1.6) * 0.85 + Math.sin(t * 0.6) * 0.15;
+}
+
+// ── Wire types ────────────────────────────────────────────────────────────────
+
+export type Pulse = { owner: number; t: number; good: boolean };
+export type GameSnapshot = {
   t: number;
   timeLeft: number;
   harmony: number;
@@ -28,15 +89,39 @@ type GameSnapshot = {
   pulses: Pulse[];
   running: boolean;
   players: number;
+  mode: TargetMode;
 };
+
 type HostMsg = { t: "offset"; v: number } | { t: "ping" };
 type GuestMsg =
-  | { t: "hello"; slot: number }
+  | { t: "hello"; slot: number; players: number }
+  | { t: "roster"; players: number }
   | { t: "start" }
   | { t: "state"; s: GameSnapshot }
-  | { t: "burst"; good: boolean }
-  | { t: "end"; harmony: string }
+  | { t: "burst"; good: boolean; tier: BurstTier; sync: number }
+  | { t: "end"; harmony: string; topMessage: string }
   | { t: "reject"; reason?: string };
+
+type BurstTier = "spark" | "team" | "constellation";
+
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((x) => typeof x === "number");
+}
+
+function isPulseArray(value: unknown): value is Pulse[] {
+  if (!Array.isArray(value)) return false;
+  return value.every(
+    (p) =>
+      typeof p === "object" &&
+      p !== null &&
+      "owner" in p &&
+      "t" in p &&
+      "good" in p &&
+      typeof p.owner === "number" &&
+      typeof p.t === "number" &&
+      typeof p.good === "boolean"
+  );
+}
 
 function isHostMsg(value: unknown): value is HostMsg {
   if (typeof value !== "object" || value === null) return false;
@@ -49,10 +134,19 @@ function isHostMsg(value: unknown): value is HostMsg {
 function isGuestMsg(value: unknown): value is GuestMsg {
   if (typeof value !== "object" || value === null) return false;
   if (!("t" in value) || typeof value.t !== "string") return false;
-  return ["hello", "start", "state", "burst", "end", "reject"].includes(value.t);
+  return ["hello", "roster", "start", "state", "burst", "end", "reject"].includes(value.t);
 }
 
-/** Callbacks the page provides so the game engine can update UI reactively. */
+// ── Public surface ────────────────────────────────────────────────────────────
+
+export interface PlayerInfo {
+  slot: number;
+  color: string;
+  label: string;
+  isYou: boolean;
+}
+
+/** Callbacks the page provides so the engine can drive UI reactively. */
 export interface SignalWeaveCallbacks {
   onLobbyStatus(text: string): void;
   onRoomCode(code: string): void;
@@ -60,11 +154,14 @@ export interface SignalWeaveCallbacks {
   onStartEnabled(enabled: boolean): void;
   onGameStart(): void;
   onSlot(label: string): void;
+  onRoster(players: PlayerInfo[]): void;
   onHud(timeLeft: number, harmony: number, combo: number): void;
+  onMode(label: string, color: string): void;
   onLog(text: string, kind: string): void;
   onNetStatus(text: string): void;
   onOffset(rawValue: number, label: string): void;
   onFlash(kind: string): void;
+  onMilestone(text: string): void;
 }
 
 /** Imperative controls returned to the page after mounting. */
@@ -77,10 +174,8 @@ export interface SignalWeaveControls {
   destroy(): void;
 }
 
-/**
- * Mount the Signal Weave game engine.
- * Call from `onMount`; call `destroy()` (or the returned controls' `destroy`) from `onDestroy`.
- */
+// ── Mount ─────────────────────────────────────────────────────────────────────
+
 export function mount(
   canvas: HTMLCanvasElement,
   callbacks: SignalWeaveCallbacks
@@ -89,40 +184,45 @@ export function mount(
   if (!rawCtx) throw new Error("Canvas 2D context unavailable");
   const ctx = rawCtx;
 
-  // ── NETWORK STATE ──────────────────────────────────────────────────────────
+  // ── Network state ──────────────────────────────────────────────────────────
   let peer: Peer | null = null;
-  let conn: DataConnection | null = null;
-  let conns: (DataConnection | null)[] = [null];
+  let conn: DataConnection | null = null; // guest's connection to host
+  let conns: (DataConnection | null)[] = [null]; // host's connections, indexed by slot (slot 0 = host self)
   let isHost = false;
   let mySlot = -1;
   let roomCode = "";
 
-  // ── GAME STATE ─────────────────────────────────────────────────────────────
+  // ── Game state ─────────────────────────────────────────────────────────────
   const state: {
     running: boolean;
     t: number;
     timeLeft: number;
     harmony: number;
     combo: number;
-    offsets: [number, number];
-    lastPing: [number, number];
+    offsets: number[];
+    lastPing: number[];
     pulses: Pulse[];
     players: number;
+    milestonesReached: Set<number>;
+    bestCombo: number;
   } = {
     running: false,
     t: 0,
-    timeLeft: 90,
+    timeLeft: ROUND_DURATION,
     harmony: 0,
     combo: 0,
-    offsets: [0, Math.PI * 0.5],
-    lastPing: [-99, -99],
+    offsets: [0, Math.PI * 0.5, 0, 0, 0, 0],
+    lastPing: [-99, -99, -99, -99, -99, -99],
     pulses: [],
     players: 1,
+    milestonesReached: new Set(),
+    bestCombo: 0,
   };
   let localSnapshot: GameSnapshot | null = null;
   let currentOffsetRaw = 0;
+  let lastModeAnnounced: TargetMode | null = null;
 
-  // ── HELPERS ────────────────────────────────────────────────────────────────
+  // ── Helpers ────────────────────────────────────────────────────────────────
   function log(text: string, kind = "") {
     callbacks.onLog(text, kind);
     callbacks.onNetStatus(text);
@@ -135,36 +235,90 @@ export function mount(
     }
   }
 
-  // ── MATH ──────────────────────────────────────────────────────────────────
-  function signalValue(t: number, offsets: number[]): number {
-    return (Math.sin(t * 2.0 + (offsets[0] ?? 0)) + Math.sin(t * 2.7 + (offsets[1] ?? 0))) * 0.5;
-  }
-  function targetValue(t: number): number {
-    return Math.sin(t * 1.5 + Math.sin(t * 0.4) * 1.2);
+  function pushRoster() {
+    const roster: PlayerInfo[] = [];
+    for (let i = 0; i < state.players; i++) {
+      const comp = componentFor(i);
+      roster.push({ slot: i, color: comp.color, label: comp.label, isYou: i === mySlot });
+    }
+    callbacks.onRoster(roster);
   }
 
-  // ── HOST LOGIC ─────────────────────────────────────────────────────────────
+  function announceMilestone(text: string) {
+    callbacks.onMilestone(text);
+    log(text, "good");
+  }
+
+  // ── Math ───────────────────────────────────────────────────────────────────
+  function signalValue(t: number, offsets: number[], players: number): number {
+    let acc = 0;
+    const n = Math.max(1, players);
+    for (let i = 0; i < n; i++) {
+      const comp = componentFor(i);
+      acc += Math.sin(t * comp.freq + (offsets[i] ?? 0));
+    }
+    return acc / n;
+  }
+
+  // ── Host logic ─────────────────────────────────────────────────────────────
   function hostTick(dt: number) {
     if (!state.running) return;
     state.t += dt;
     state.timeLeft = Math.max(0, state.timeLeft - dt);
-    const comboFactor = 1 + Math.min(5, state.combo) * 0.15;
-    const diff = Math.abs(signalValue(state.t, state.offsets) - targetValue(state.t));
 
-    if (diff < HARMONY_THRESHOLD) state.harmony += dt * HARMONY_GAIN_RATE * comboFactor;
-    else state.harmony = Math.max(0, state.harmony - dt * 5);
+    const comboFactor = 1 + Math.min(8, state.combo) * 0.18;
+    const diff = Math.abs(
+      signalValue(state.t, state.offsets, state.players) - targetValue(state.t)
+    );
 
-    if (
-      state.combo > 0 &&
-      state.t - Math.max(state.lastPing[0], state.lastPing[1]) > COMBO_TIMEOUT_SECONDS
-    )
-      state.combo = 0;
+    if (diff < HARMONY_THRESHOLD) {
+      state.harmony += dt * HARMONY_GAIN_RATE * comboFactor;
+    } else {
+      state.harmony = Math.max(0, state.harmony - dt * 5);
+    }
+
+    if (state.combo > 0) {
+      const last = Math.max(...state.lastPing.slice(0, state.players));
+      if (state.t - last > COMBO_TIMEOUT_SECONDS) state.combo = 0;
+    }
+
+    // Milestones (first time crossed only)
+    for (const mile of [50, 100, 200, 350, 500, 750]) {
+      if (state.harmony >= mile && !state.milestonesReached.has(mile)) {
+        state.milestonesReached.add(mile);
+        announceMilestone(`HARMONY ${mile} REACHED`);
+      }
+    }
+    if (state.combo >= 3 && state.combo > state.bestCombo) {
+      state.bestCombo = state.combo;
+      if (state.combo === 3 || state.combo === 5 || state.combo === 8 || state.combo === 12) {
+        announceMilestone(`${state.combo}x CONSTELLATION`);
+      }
+    }
+
     state.pulses = state.pulses.filter((p) => state.t - p.t < 2.4);
+
+    // Mode announcements when target movement changes
+    const m = modeAt(state.t);
+    if (m !== lastModeAnnounced) {
+      lastModeAnnounced = m;
+      callbacks.onMode(MODE_LABEL[m], MODE_PALETTE[m]);
+      log(MODE_LABEL[m]);
+    }
 
     if (state.timeLeft <= 0) {
       state.running = false;
-      broadcast({ t: "end", harmony: state.harmony.toFixed(1) });
-      log("Weave complete. Harmony: " + state.harmony.toFixed(1));
+      const top =
+        state.bestCombo >= 8
+          ? "Constellation forged."
+          : state.bestCombo >= 5
+            ? "Tight weave."
+            : state.harmony > 200
+              ? "Steady hands."
+              : "Round complete.";
+      broadcast({ t: "end", harmony: state.harmony.toFixed(1), topMessage: top });
+      log(`Weave complete. Harmony ${state.harmony.toFixed(1)} • Best combo ${state.bestCombo}.`);
+      announceMilestone(top);
     }
   }
 
@@ -174,53 +328,83 @@ export function mount(
       timeLeft: state.timeLeft,
       harmony: state.harmony,
       combo: state.combo,
-      offsets: state.offsets,
+      offsets: state.offsets.slice(),
       pulses: state.pulses,
       running: state.running,
       players: state.players,
+      mode: modeAt(state.t),
     };
   }
 
   function sendState() {
-    const data = { t: "state", s: hostSnapshot() };
+    const data: GuestMsg = { t: "state", s: hostSnapshot() };
     localSnapshot = data.s;
     broadcast(data);
   }
 
+  function syncedPlayerCount(now: number): number {
+    let count = 0;
+    for (let i = 0; i < state.players; i++) {
+      const last = state.lastPing[i] ?? -99;
+      if (now - last <= PULSE_SYNC_WINDOW_SECONDS) count += 1;
+    }
+    return count;
+  }
+
   function onPing(slot: number) {
+    if (!state.running) return;
     const now = state.t;
     state.lastPing[slot] = now;
     state.pulses.push({ owner: slot, t: now, good: false });
-    const other = slot === 0 ? 1 : 0;
-    if (state.players >= 2 && now - (state.lastPing[other] ?? -99) < PULSE_SYNC_WINDOW_SECONDS) {
-      const aligned = Math.abs(signalValue(state.t, state.offsets) - targetValue(state.t)) < 0.2;
-      if (aligned) {
-        state.combo += 1;
-        state.harmony += 16 + Math.min(state.combo, 6) * 2;
-        state.pulses.push({ owner: slot, t: now, good: true });
-        broadcast({ t: "burst", good: true });
-        callbacks.onFlash("good");
-        log("Synchronized constructive pulse.", "good");
-      } else {
-        state.combo = 0;
-        state.harmony = Math.max(0, state.harmony - 6);
-        broadcast({ t: "burst", good: false });
-        callbacks.onFlash("bad");
-        log("Pulse collided out of phase.", "bad");
-      }
-    } else if (state.players < 2) {
-      log("Awaiting second operator for synchronized pulse.");
+
+    const synced = syncedPlayerCount(now);
+    if (synced < 2) {
+      // Solo pulse — neutral
+      return;
+    }
+
+    const tolerance = 0.18 + Math.max(0, state.players - 2) * 0.04;
+    const aligned =
+      Math.abs(signalValue(state.t, state.offsets, state.players) - targetValue(state.t)) <
+      tolerance;
+
+    if (aligned) {
+      const allIn = synced === state.players;
+      const tier: BurstTier = allIn ? "constellation" : synced >= 3 ? "team" : "spark";
+      const baseGain = tier === "constellation" ? 28 : tier === "team" ? 18 : 12;
+      const comboBonus = Math.min(state.combo, 8) * 2;
+      state.combo += 1;
+      state.harmony += baseGain + comboBonus;
+      state.pulses.push({ owner: slot, t: now, good: true });
+      broadcast({ t: "burst", good: true, tier, sync: synced });
+      callbacks.onFlash(tier === "constellation" ? "perfect" : "good");
+      const msg =
+        tier === "constellation"
+          ? `Full constellation (${synced}/${state.players}) — +${baseGain + comboBonus} harmony.`
+          : tier === "team"
+            ? `Team burst (${synced}/${state.players}) — +${baseGain + comboBonus}.`
+            : `Pair pulse — +${baseGain + comboBonus}.`;
+      log(msg, "good");
+    } else {
+      state.combo = 0;
+      state.harmony = Math.max(0, state.harmony - 6);
+      broadcast({ t: "burst", good: false, tier: "spark", sync: synced });
+      callbacks.onFlash("bad");
+      log(`Pulse out of phase (${synced} synced).`, "bad");
     }
   }
 
   function startRound() {
     state.running = true;
     state.t = 0;
-    state.timeLeft = 90;
+    state.timeLeft = ROUND_DURATION;
     state.harmony = 0;
     state.combo = 0;
+    state.bestCombo = 0;
+    state.milestonesReached = new Set();
     state.pulses = [];
-    state.lastPing = [-99, -99];
+    state.lastPing = state.lastPing.map(() => -99);
+    lastModeAnnounced = null;
     sendState();
     broadcast({ t: "start" });
     callbacks.onGameStart();
@@ -242,7 +426,49 @@ export function mount(
     mySlot = -1;
   }
 
-  // ── NETWORKING ─────────────────────────────────────────────────────────────
+  // ── Networking ─────────────────────────────────────────────────────────────
+  function attachGuestConn(c: DataConnection, slot: number) {
+    conns[slot] = c;
+    c.on("open", () => {
+      state.players = Math.max(state.players, slot + 1);
+      c.send({ t: "hello", slot, players: state.players });
+      // tell everyone the new roster size
+      broadcast({ t: "roster", players: state.players });
+      callbacks.onStartEnabled(state.players >= MIN_PLAYERS);
+      callbacks.onLobbyStatus(
+        state.players >= MAX_PLAYERS
+          ? "All operator slots filled. Ready to begin."
+          : `Operator ${slot + 1} connected. Ready to begin. (${state.players}/${MAX_PLAYERS})`
+      );
+      log(`Operator ${slot + 1} tuned in.`, "good");
+      pushRoster();
+    });
+    c.on("data", (d: unknown) => {
+      if (isHostMsg(d)) onHostMessage(d, slot);
+    });
+    c.on("close", () => {
+      conns[slot] = null;
+      // Recompute player count from active conns
+      let highest = 0;
+      for (let i = 1; i < conns.length; i++) {
+        if (conns[i]?.open) highest = i;
+      }
+      state.players = highest + 1; // includes host slot 0
+      callbacks.onStartEnabled(state.players >= MIN_PLAYERS && !state.running);
+      broadcast({ t: "roster", players: state.players });
+      callbacks.onLobbyStatus(`Operator ${slot + 1} disconnected.`);
+      log(`Operator ${slot + 1} dropped.`, "bad");
+      pushRoster();
+    });
+  }
+
+  function nextFreeSlot(): number {
+    for (let i = 1; i < MAX_PLAYERS; i++) {
+      if (!conns[i] || !conns[i]?.open) return i;
+    }
+    return -1;
+  }
+
   function hostGame() {
     if (typeof Peer === "undefined") return callbacks.onLobbyStatus("PeerJS failed to load.");
     resetNet();
@@ -255,40 +481,29 @@ export function mount(
     callbacks.onRoomWrapVisible(true);
     callbacks.onStartEnabled(false);
     callbacks.onLobbyStatus("Opening channel...");
+    pushRoster();
 
     peer = new Peer(PEER_PREFIX + roomCode);
-    peer.on("open", () => callbacks.onLobbyStatus("Channel open. Waiting for operator 2."));
+    peer.on("open", () =>
+      callbacks.onLobbyStatus(
+        `Channel open. Waiting for operators. (1/${MAX_PLAYERS}, min ${MIN_PLAYERS})`
+      )
+    );
     peer.on("connection", (c) => {
-      if (state.players >= MAX_PLAYERS || state.running) {
+      const slot = nextFreeSlot();
+      if (slot < 0 || state.running) {
         c.on("open", () => {
           c.send({
             t: "reject",
-            reason: state.running ? "Game already in progress." : "Room is full.",
+            reason: state.running ? "Round already in progress." : "Room is full.",
           });
           c.close();
         });
         return;
       }
-      conns[1] = c;
-      c.on("open", () => {
-        state.players = 2;
-        c.send({ t: "hello", slot: 1 });
-        callbacks.onStartEnabled(true);
-        callbacks.onLobbyStatus("Operator connected. Ready to begin.");
-        log("Second operator tuned in.");
-      });
-      c.on("data", (d: unknown) => {
-        if (isHostMsg(d)) {
-          onHostMessage(d, 1);
-        }
-      });
-      c.on("close", () => {
-        state.players = 1;
-        conns[1] = null;
-        callbacks.onStartEnabled(false);
-        callbacks.onLobbyStatus("Operator disconnected.");
-        log("Peer disconnected.", "bad");
-      });
+      // Make sure the conns array is big enough
+      while (conns.length <= slot) conns.push(null);
+      attachGuestConn(c, slot);
     });
     peer.on("error", (e) => callbacks.onLobbyStatus("Host peer error: " + describePeerError(e)));
   }
@@ -305,9 +520,7 @@ export function mount(
       conn = p.connect(PEER_PREFIX + code, { reliable: true });
       conn.on("open", () => callbacks.onLobbyStatus("Connected. Awaiting host start."));
       conn.on("data", (d: unknown) => {
-        if (isGuestMsg(d)) {
-          onGuestMessage(d);
-        }
+        if (isGuestMsg(d)) onGuestMessage(d);
       });
       conn.on("close", () => callbacks.onLobbyStatus("Disconnected from host."));
     });
@@ -325,27 +538,36 @@ export function mount(
   function onGuestMessage(d: GuestMsg) {
     if (d.t === "hello") {
       mySlot = d.slot;
+      state.players = d.players;
       callbacks.onSlot("P" + (mySlot + 1));
       callbacks.onLobbyStatus("Linked as operator " + (mySlot + 1) + ".");
+      pushRoster();
+    } else if (d.t === "roster") {
+      state.players = d.players;
+      pushRoster();
     } else if (d.t === "start") {
       callbacks.onGameStart();
       log("Host started the weave.");
     } else if (d.t === "state") {
       localSnapshot = d.s;
+      // mirror what the host knows so we draw consistently
+      state.players = d.s.players;
+      callbacks.onMode(MODE_LABEL[d.s.mode], MODE_PALETTE[d.s.mode]);
     } else if (d.t === "burst") {
-      callbacks.onFlash(d.good ? "good" : "bad");
+      callbacks.onFlash(d.good ? (d.tier === "constellation" ? "perfect" : "good") : "bad");
       log(
-        d.good ? "Synchronized constructive pulse." : "Pulse collided out of phase.",
+        d.good ? `Burst (${d.sync} synced).` : `Pulse out of phase (${d.sync} synced).`,
         d.good ? "good" : "bad"
       );
     } else if (d.t === "end") {
-      log("Weave complete. Harmony: " + d.harmony);
+      log(`Weave complete. Harmony ${d.harmony}.`, "good");
+      callbacks.onMilestone(d.topMessage);
     } else if (d.t === "reject") {
       callbacks.onLobbyStatus(d.reason ?? "Unable to join room.");
     }
   }
 
-  // ── CONTROLS ───────────────────────────────────────────────────────────────
+  // ── Controls ───────────────────────────────────────────────────────────────
   function setOffset(rawValue: number) {
     currentOffsetRaw = rawValue;
     const v = rawValue / OFFSET_SCALE;
@@ -363,7 +585,7 @@ export function mount(
     else if (conn && conn.open) conn.send({ t: "ping" });
   }
 
-  // ── KEYBOARD ──────────────────────────────────────────────────────────────
+  // ── Keyboard ──────────────────────────────────────────────────────────────
   function handleKeyDown(e: KeyboardEvent) {
     if (e.code === "Space") {
       e.preventDefault();
@@ -376,7 +598,7 @@ export function mount(
   }
   window.addEventListener("keydown", handleKeyDown);
 
-  // ── GAME LOOP + DRAW ───────────────────────────────────────────────────────
+  // ── Game loop + draw ───────────────────────────────────────────────────────
   let netTimer = 0;
   const gameLoop = createGameLoop((dt) => {
     if (isHost) {
@@ -391,8 +613,8 @@ export function mount(
   });
 
   function draw(snapshot: GameSnapshot) {
-    const w = canvas.clientWidth,
-      h = canvas.clientHeight;
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
     if (canvas.width !== w || canvas.height !== h) {
       canvas.width = w;
       canvas.height = h;
@@ -400,13 +622,15 @@ export function mount(
     ctx.clearRect(0, 0, w, h);
 
     const midY = h * 0.5;
-    const left = 30,
-      right = w - 30,
-      span = right - left;
+    const left = 30;
+    const right = w - 30;
+    const span = right - left;
     const amp = h * 0.22;
     const s = snapshot;
     const now = s.t || 0;
+    const playerCount = Math.max(1, s.players ?? 1);
 
+    // grid
     ctx.strokeStyle = "#1f2d56";
     ctx.lineWidth = 1;
     for (let i = 0; i <= 8; i++) {
@@ -434,13 +658,35 @@ export function mount(
     }
 
     const offs = s.offsets;
-    drawWave((t) => targetValue(t), "#ff7ccf", 2.5, 0.95);
-    drawWave((t) => signalValue(t, offs), "#79f3ff", 2.5, 0.95);
-    drawWave((t) => Math.sin(t * 2.0 + (offs[0] ?? 0)), "#8ef9ff", 1.2, 0.35);
-    drawWave((t) => Math.sin(t * 2.7 + (offs[1] ?? 0)), "#6bb4ff", 1.2, 0.35);
 
+    // target wave (mode-tinted)
+    drawWave((t) => targetValue(t), MODE_PALETTE[s.mode] ?? "#ff7ccf", 2.6, 0.95);
+
+    // each player's contribution at low alpha (so you can see your slice)
+    for (let i = 0; i < playerCount; i++) {
+      const comp = componentFor(i);
+      drawWave(
+        (t) => Math.sin(t * comp.freq + (offs[i] ?? 0)) / playerCount,
+        comp.color,
+        1.1,
+        0.45
+      );
+    }
+
+    // combined signal in cyan
+    drawWave((t) => signalValue(t, offs, playerCount), "#79f3ff", 2.6, 0.95);
+
+    // playhead
+    const px = left + span * 0.5;
+    ctx.strokeStyle = "rgba(255,255,255,0.25)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(px, midY - amp);
+    ctx.lineTo(px, midY + amp);
+    ctx.stroke();
+
+    // pulses
     const pulses = s.pulses;
-    const playerCount = Math.max(1, s.players ?? 1);
     const playerDenom = playerCount > 1 ? playerCount - 1 : 1;
     for (const p of pulses) {
       const age = now - p.t;
@@ -449,9 +695,10 @@ export function mount(
       const r = 20 + age * 120;
       ctx.beginPath();
       ctx.arc(x, midY, r, 0, Math.PI * 2);
+      const ownerColor = COMPONENTS[p.owner]?.color ?? "#79f3ff";
       ctx.strokeStyle = p.good
         ? "rgba(141,255,157," + (1 - age / 2.4).toFixed(3) + ")"
-        : "rgba(121,243,255," + (1 - age / 2.4).toFixed(3) + ")";
+        : `rgba(${hexAlpha(ownerColor, 1 - age / 2.4)})`;
       ctx.lineWidth = p.good ? 3 : 1.5;
       ctx.stroke();
     }
@@ -459,8 +706,22 @@ export function mount(
     callbacks.onHud(s.timeLeft || 0, s.harmony || 0, s.combo || 0);
   }
 
-  // ── LIFECYCLE ─────────────────────────────────────────────────────────────
+  function hexAlpha(hex: string, a: number): string {
+    // hex "#rrggbb" → "r,g,b,a"
+    const r = parseInt(hex.slice(1, 3), 16) || 0;
+    const g = parseInt(hex.slice(3, 5), 16) || 0;
+    const b = parseInt(hex.slice(5, 7), 16) || 0;
+    return `${r},${g},${b},${a.toFixed(3)}`;
+  }
+
+  // unused — kept for future N>2 host rejoin path
+  void isNumberArray;
+  void isPulseArray;
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
   setOffset(0); // initialise label
+  callbacks.onMode(MODE_LABEL.drift, MODE_PALETTE.drift);
+  pushRoster();
   gameLoop.start();
 
   function destroy() {
@@ -473,7 +734,7 @@ export function mount(
     hostGame,
     joinGame,
     startGame: () => {
-      if (isHost && state.players >= 2) startRound();
+      if (isHost && state.players >= MIN_PLAYERS) startRound();
     },
     setOffset,
     pulse: doPulse,

--- a/src/routes/games/signal-weave/+page.svelte
+++ b/src/routes/games/signal-weave/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from "svelte";
   import "./style.css";
   import { OFFSET_MIN, OFFSET_MAX } from "$lib/games/signal-weave/main";
-  import type { SignalWeaveControls } from "$lib/games/signal-weave/main";
+  import type { SignalWeaveControls, PlayerInfo } from "$lib/games/signal-weave/main";
   import {
     buildRoomShareUrl,
     clearRoomCodeFromUrl,
@@ -43,11 +43,18 @@
   let hudTime = $state("90.0");
   let hudHarmony = $state("0.0");
   let hudCombo = $state("x0");
+  let modeLabel = $state("MOV. I — DRIFT");
+  let modeColor = $state("#ff7ccf");
+  let roster = $state<PlayerInfo[]>([]);
+  let milestone = $state("");
+  let milestoneTimer: ReturnType<typeof setTimeout> | undefined;
 
   interface LogEntry {
+    id: number;
     text: string;
     kind: string;
   }
+  let logSeq = 0;
   let logs = $state<LogEntry[]>([]);
   let netStatus = $state("Idle.");
   let offsetLabel = $state("0.00 rad");
@@ -86,7 +93,8 @@
         hudCombo = "x" + c;
       },
       onLog: (text, kind) => {
-        logs = [{ text, kind }, ...logs].slice(0, 20);
+        logSeq += 1;
+        logs = [{ id: logSeq, text, kind }, ...logs].slice(0, 20);
       },
       onNetStatus: (t) => {
         netStatus = t;
@@ -99,7 +107,21 @@
         flashClass = k;
         setTimeout(() => {
           flashClass = "";
-        }, 140);
+        }, 200);
+      },
+      onMode: (label, color) => {
+        modeLabel = label;
+        modeColor = color;
+      },
+      onRoster: (next) => {
+        roster = next;
+      },
+      onMilestone: (text) => {
+        milestone = text;
+        if (milestoneTimer !== undefined) clearTimeout(milestoneTimer);
+        milestoneTimer = setTimeout(() => {
+          milestone = "";
+        }, 2400);
       },
     });
 
@@ -114,6 +136,7 @@
   onDestroy(() => {
     controls?.destroy();
     if (copyStatusTimer !== undefined) clearTimeout(copyStatusTimer);
+    if (milestoneTimer !== undefined) clearTimeout(milestoneTimer);
   });
 </script>
 
@@ -126,8 +149,11 @@
     <div id="lobby">
       <div class="card">
         <h1>SIGNAL WEAVE</h1>
-        <p>Two operators shape one impossible waveform.</p>
-        <p>Match the target signal and fire synchronized pulses.</p>
+        <p>Two to six operators shape one impossible waveform.</p>
+        <p>
+          Each slot owns its own sine component. Slide your phase to match the magenta target, then
+          fire synchronized pulses for combo bursts.
+        </p>
         <div class="row" style="margin-top:10px">
           <button id="host-btn" onclick={() => controls?.hostGame()}>OPEN CHANNEL</button>
         </div>
@@ -155,6 +181,15 @@
                 {copyStatus}
               </p>
             {/if}
+            {#if roster.length}
+              <div id="lobby-roster" class="lobby-roster">
+                {#each roster as p (p.slot)}
+                  <span class="op-chip" style:border-color={p.color} style:color={p.color}>
+                    P{p.slot + 1} · {p.label}{p.isYou ? " (you)" : ""}
+                  </span>
+                {/each}
+              </div>
+            {/if}
             <button id="start-btn" disabled={!startEnabled} onclick={() => controls?.startGame()}
               >BEGIN WEAVE</button
             >
@@ -173,8 +208,14 @@
         <div class="chip">HARMONY <b>{hudHarmony}</b></div>
         <div class="chip">COMBO <b>{hudCombo}</b></div>
         <div class="chip">YOU <b id="slot">{slotLabel}</b></div>
+        <div class="chip" id="mode-chip" style:color={modeColor} style:border-color={modeColor}>
+          {modeLabel}
+        </div>
       </div>
       <div id="flash" class={flashClass} style:opacity={flashClass ? "1" : "0"}></div>
+      {#if milestone}
+        <div id="milestone" role="status" aria-live="polite">{milestone}</div>
+      {/if}
     </div>
     <div id="sidebar">
       <div class="panel">
@@ -194,10 +235,26 @@
         </div>
       </div>
       <div class="panel">
+        <h3>OPERATORS</h3>
+        <div id="game-roster" class="game-roster">
+          {#each roster as p (p.slot)}
+            <div class="op-row">
+              <span class="op-dot" style:background={p.color}></span>
+              <span style:color={p.color}>P{p.slot + 1} · {p.label}</span>
+              {#if p.isYou}<span class="you-tag">you</span>{/if}
+            </div>
+          {:else}
+            <div style="color:var(--dim)">solo</div>
+          {/each}
+        </div>
+      </div>
+      <div class="panel">
         <h3>PROTOCOL</h3>
-        <div style="color:var(--dim)">
-          Keep the cyan combined wave close to the magenta target.<br />
-          Synchronized pulses (&lt; 0.8s apart) amplify harmony when alignment is good.
+        <div style="color:var(--dim);font-size:12px">
+          Each operator owns one sine component. Slide your phase to match the magenta target.<br />
+          <b>Pair pulse</b> = 2 ops within 0.85 s · <b>Team burst</b> = 3+ · <b>Constellation</b> =
+          all of you in sync. Bigger sync, bigger harmony.<br />
+          Movements rotate every 25 s — drift, double, tempest.
         </div>
       </div>
       <div class="panel">
@@ -207,7 +264,7 @@
       <div class="panel">
         <h3>LOG</h3>
         <div id="log">
-          {#each logs as entry, i (i)}
+          {#each logs as entry (entry.id)}
             <div class={entry.kind}>{entry.text}</div>
           {/each}
         </div>

--- a/src/routes/games/signal-weave/style.css
+++ b/src/routes/games/signal-weave/style.css
@@ -174,14 +174,92 @@
     inset: 0;
     pointer-events: none;
     opacity: 0;
-    transition: opacity 0.18s;
+    transition: opacity 0.22s;
     z-index: 1;
   }
   #flash.good {
     background: radial-gradient(circle, rgba(141, 255, 157, 0.22), transparent 55%);
   }
+  #flash.perfect {
+    background: radial-gradient(circle, rgba(255, 221, 0, 0.45), transparent 60%);
+  }
   #flash.bad {
     background: radial-gradient(circle, rgba(255, 124, 207, 0.2), transparent 55%);
+  }
+  #milestone {
+    position: absolute;
+    top: 56%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 5;
+    padding: 8px 18px;
+    border: 1px solid var(--acc);
+    color: var(--acc);
+    background: rgba(8, 14, 32, 0.85);
+    font-size: 18px;
+    letter-spacing: 0.18em;
+    text-shadow: 0 0 12px rgba(121, 243, 255, 0.6);
+    pointer-events: none;
+    animation: milestone-pop 2.4s ease-out forwards;
+  }
+  @keyframes milestone-pop {
+    0% {
+      opacity: 0;
+      transform: translate(-50%, calc(-50% + 8px));
+    }
+    15% {
+      opacity: 1;
+      transform: translate(-50%, -50%);
+    }
+    85% {
+      opacity: 1;
+      transform: translate(-50%, calc(-50% - 4px));
+    }
+    100% {
+      opacity: 0;
+      transform: translate(-50%, calc(-50% - 16px));
+    }
+  }
+  #mode-chip {
+    border-color: var(--hot);
+    color: var(--hot);
+  }
+  .lobby-roster {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 8px;
+  }
+  .op-chip {
+    padding: 3px 8px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    background: rgba(8, 14, 32, 0.4);
+  }
+  .game-roster {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+  }
+  .op-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    letter-spacing: 0.05em;
+  }
+  .op-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    box-shadow: 0 0 6px currentColor;
+  }
+  .you-tag {
+    color: var(--dim);
+    font-size: 10px;
+    letter-spacing: 0.2em;
   }
   #log {
     max-height: 180px;


### PR DESCRIPTION
> 🤖 This PR was authored by an AI assistant (Claude Code). A human
> reviewer should run a 3-4 client multiplayer test in a browser
> before merge.

## Summary
Rebuild the Signal Weave round so the gameplay scales past two
players and has more to react to during a 90 s shift.

### Roster
- Up to **6 operators** per room (was a hard 2-cap). Lobby reports
  `(N/6, min 2)` so hosts know how many slots are open.
- Each slot owns a distinct sine component (frequency + colour +
  call-letter label). Combined signal = mean of N component sines.

### Target movements
- Target wave cycles through three movements every 25 s — **Drift**,
  **Double**, **Tempest** — with progressively more modulation.
  Mode chip on the HUD + log line on transition.

### Synchronized bursts
- Pulses now tier by how many operators fire within 0.85 s when the
  combined signal is in phase: **Pair** (2), **Team** (3+),
  **Constellation** (everyone). Bigger sync = more harmony, larger
  combo bonus, brighter flash.
- Combo bonus scales with synced count; alignment tolerance loosens
  slightly per extra operator so 5–6 player weaves stay solvable.
- Best combo tracked and reported at end; combo rungs (3x / 5x /
  8x / 12x) flash as in-stage milestones, alongside harmony
  milestones (50, 100, 200, 350, 500, 750).

### UI / engine
- New callbacks: `onMode`, `onRoster`, `onMilestone`.
- Page renders a mode chip, an in-stage milestone overlay, a lobby
  roster and an in-game `OPERATORS` panel with each player's
  call-letter colour.
- Per-player wave traces drawn underneath the combined signal at
  low alpha so each operator can see their own slice.
- Logs use stable monotonic ids so the duplicate-collapse fix from
  PR #45 carries over.

## Backwards-compatibility
The existing lobby selectors are preserved: `#host-btn`,
`#join-btn`, `#start-btn`, `#room-code`, `#room-wrap`,
`#join-code`, `#lobby-status`, `#slot`. Wording for the lobby
status events keeps `Ready to begin.` and `Linked as operator N.`
so the Playwright multiplayer-lobby test keeps passing.

## Test plan
- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npx prettier --check src/`
- [x] `npm run build`
- [x] Local Playwright: `tests/multiplayer-lobby.test.ts` and
      `tests/smoke.test.ts` both green (20/20) against a glibc
      Playwright runner.
- [ ] Manually with 3-4 browsers / tabs: host a room, join with 3+
      operators, verify each slot's slider only affects its colour
      band, sync pulses produce Pair / Team / Constellation tiers,
      mode chip rotates every 25 s, end log reports best combo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)