### PR TITLE
Deconstruct follow-up fixes (#48)

### DIFF
--- a/src/lib/games/deconstruct/gameState.svelte.ts
+++ b/src/lib/games/deconstruct/gameState.svelte.ts
@@ -1,4 +1,4 @@
-import type { Card, ColKey, ScoreEntry } from "./types.js";
+import type { Card, ColKey, MoveResult, ScoreEntry } from "./types.js";
 
 export type BlockRiseTrigger = {
   id: string;
@@ -23,7 +23,7 @@ export type LogEntry = { text: string; kind?: string };
 export type PlayerListEntry = { slot: number; name: string; color: string };
 
 export type GameState = {
-  phase: "lobby" | "game";
+  phase: "lobby" | "game" | "end";
   grid: ColKey[][][];
   myHand: Card[];
   selectedCardIdx: number | null;
@@ -47,6 +47,14 @@ export type GameState = {
   joinStatus: string;
   joinCodeInput: string;
   lobbyPanel: "menu" | "waiting" | "joining";
+  lastRoundResults: MoveResult[];
+  lastRoundTurn: number;
+  showRoundSummary: boolean;
+  invalidShake: number;
+  finalResults: {
+    winnerSlot: number;
+    scores: ScoreEntry[];
+  } | null;
 };
 
 export const gs = $state<GameState>({
@@ -74,4 +82,9 @@ export const gs = $state<GameState>({
   joinStatus: "",
   joinCodeInput: "",
   lobbyPanel: "menu",
+  lastRoundResults: [],
+  lastRoundTurn: 0,
+  showRoundSummary: false,
+  invalidShake: 0,
+  finalResults: null,
 });

--- a/src/lib/games/deconstruct/main.ts
+++ b/src/lib/games/deconstruct/main.ts
@@ -122,15 +122,19 @@ const HS: {
 };
 
 // ---- Game logic ----
-function topColor(x: number, y: number): ColKey | null {
-  const stack = gs.grid[x]?.[y] ?? [];
+function topColorIn(grid: ColKey[][][], x: number, y: number): ColKey | null {
+  const stack = grid[x]?.[y] ?? [];
   return stack.length ? (stack[stack.length - 1] ?? null) : null;
 }
 
-function validates(sel: [number, number][], card: Card): boolean {
+function topColor(x: number, y: number): ColKey | null {
+  return topColorIn(gs.grid, x, y);
+}
+
+function validatesIn(grid: ColKey[][][], sel: [number, number][], card: Card): boolean {
   if (sel.length !== card.shape.cells.length) return false;
   for (const pos of sel) {
-    if (topColor(pos[0] ?? 0, pos[1] ?? 0) !== card.color) return false;
+    if (topColorIn(grid, pos[0] ?? 0, pos[1] ?? 0) !== card.color) return false;
   }
   const norm = function (a: [number, number][]) {
     const mx = Math.min(...a.map((p) => p[0] ?? 0));
@@ -146,6 +150,10 @@ function validates(sel: [number, number][], card: Card): boolean {
     cells = mapCoordinates(cells, (x, y) => [-(y ?? 0), x ?? 0]);
   }
   return false;
+}
+
+function validates(sel: [number, number][], card: Card): boolean {
+  return validatesIn(gs.grid, sel, card);
 }
 
 function generateGrid(): ColKey[][][] {
@@ -182,6 +190,46 @@ function generateHand(): Card[] {
     });
   }
   return h.sort((a, b) => a.init - b.init);
+}
+
+/**
+ * Returns true if this card can legally be placed somewhere on the client's
+ * current grid. Used to gray-out cards that have no valid placement.
+ */
+export function cardHasPlacement(card: Card): boolean {
+  return findPlacement(gs.grid, card) !== null;
+}
+
+function findPlacement(grid: ColKey[][][], card: Card): [number, number][] | null {
+  const tops: [number, number][] = [];
+  for (let x = 0; x < W; x++)
+    for (let y = 0; y < H; y++) {
+      if (topColorIn(grid, x, y) === card.color) tops.push([x, y]);
+    }
+  let cells: [number, number][] = cloneTupleArray(card.shape.cells);
+  for (let r = 0; r < 4; r++) {
+    for (const anchor of tops) {
+      const mx = Math.min(...cells.map((p) => p[0] ?? 0));
+      const my = Math.min(...cells.map((p) => p[1] ?? 0));
+      const placed: [number, number][] = cells.map((c) => [
+        (c[0] ?? 0) - mx + (anchor[0] ?? 0),
+        (c[1] ?? 0) - my + (anchor[1] ?? 0),
+      ]);
+      if (
+        placed.every(
+          (p) =>
+            (p[0] ?? 0) >= 0 &&
+            (p[0] ?? 0) < W &&
+            (p[1] ?? 0) >= 0 &&
+            (p[1] ?? 0) < H &&
+            topColorIn(grid, p[0] ?? 0, p[1] ?? 0) === card.color
+        )
+      )
+        return placed;
+    }
+    cells = cells.map((c) => [-(c[1] ?? 0), c[0] ?? 0]);
+  }
+  return null;
 }
 
 function cpuFind(card: Card): [number, number][] | null {
@@ -337,6 +385,28 @@ function resolveTurn(moves: MoveResult[], gridAfter: ColKey[][][] | null) {
 }
 
 // ---- Host logic ----
+function refillHand(existing: Card[]): Card[] {
+  // Preserve unplayed cards across rounds; only top up to 5.
+  const used = new Set(existing.map((c) => c.init));
+  const next: Card[] = existing.slice();
+  let safety = 200;
+  while (next.length < 5 && safety-- > 0) {
+    const init = 1 + Math.floor(rand() * MAX_INITIATIVE);
+    if (used.has(init)) continue;
+    used.add(init);
+    const maxIdx = Math.min(SHAPES.length - 1, Math.floor(init / 4));
+    const shapeIdx = Math.floor(rand() * (maxIdx + 1));
+    const shape = SHAPES[shapeIdx] ?? SHAPES[0];
+    if (!shape) continue;
+    next.push({
+      init,
+      shape,
+      color: COLKEYS[Math.floor(rand() * COLKEYS.length)] ?? "R",
+    });
+  }
+  return next.sort((a, b) => a.init - b.init);
+}
+
 function hostStartRound() {
   if (HS.turn === 1) {
     HS.seed = (Math.random() * 2 ** 32) >>> 0;
@@ -346,7 +416,12 @@ function hostStartRound() {
   HS.picks = {};
   const n = HS.N;
   for (let i = 0; i < n; i++) {
-    HS.hands[i] = generateHand();
+    const existing = HS.hands[i];
+    if (HS.turn === 1 || !existing || existing.length === 0) {
+      HS.hands[i] = generateHand();
+    } else {
+      HS.hands[i] = refillHand(existing);
+    }
   }
   const scores: ScoreEntry[] = [];
   for (let i = 0; i < n; i++) {
@@ -408,20 +483,28 @@ function hostResolveTurn() {
       results.push({ slot: act.slot, card: null, sel: null, points: 0 });
       continue;
     }
-    if (act.sel && validates(act.sel, act.card)) {
+    const playedCard = act.card;
+    if (act.sel && validatesIn(HS.grid, act.sel, playedCard)) {
       removeCubes(act.sel);
       const pts = act.sel.length;
       HS.scores[act.slot] = (HS.scores[act.slot] || 0) + pts;
+      // Remove the played card from the player's hand so unplayed cards persist.
+      const hand = HS.hands[act.slot];
+      if (hand) HS.hands[act.slot] = hand.filter((c) => c.init !== playedCard.init);
       results.push({
         slot: act.slot,
-        card: act.card,
+        card: playedCard,
         sel: act.sel,
         points: pts,
       });
     } else {
+      // Played card was invalid (silent channel). Still consume it so players can't
+      // retry the same dud card indefinitely.
+      const hand = HS.hands[act.slot];
+      if (hand) HS.hands[act.slot] = hand.filter((c) => c.init !== playedCard.init);
       results.push({
         slot: act.slot,
-        card: act.card,
+        card: playedCard,
         sel: act.sel,
         points: 0,
       });
@@ -491,6 +574,7 @@ function onRoundStart(data: RoundStartMsg) {
   gs.mySlot = data.yourSlot;
   mySlot = data.yourSlot;
   showWait(false);
+  gs.showRoundSummary = false;
   if (data.turn === 1)
     log(
       "▶ Transmission detected. Select a filter card, then click matching tiles on the grid.",
@@ -500,7 +584,6 @@ function onRoundStart(data: RoundStartMsg) {
 
 function onTurnResult(data: TurnResultMsg) {
   gs.allScores = data.scores;
-  gs.turn = data.turn;
   gs.playerNames = Object.fromEntries(
     Object.entries(data.names)
       .map(([k, v]) => [parseInt(k, 10), v])
@@ -510,10 +593,15 @@ function onTurnResult(data: TurnResultMsg) {
   gs.selectedCardIdx = null;
   gs.selected = [];
 
+  // Remember which turn just completed (data.turn is already advanced to the next round).
+  const completedTurn = Math.max(1, data.turn - 1);
+  gs.lastRoundResults = data.results;
+  gs.lastRoundTurn = completedTurn;
+
   resolveTurn(data.results, data.grid);
 
+  const totalDelay = data.results.length * 450 + 1200;
   if (data.gameOver) {
-    const totalDelay = data.results.length * 450 + 1200;
     setTimeout(function () {
       let msg: string;
       if (data.winnerSlot === WINNER_TIED) msg = "Signal split — tied transmission!";
@@ -523,8 +611,70 @@ function onTurnResult(data: TurnResultMsg) {
       log("━━ CARRIER LOST — " + msg + " ━━", "ok");
       log(scoreText);
       showMsg(msg, "ok");
+      gs.finalResults = { winnerSlot: data.winnerSlot, scores: data.scores };
+      gs.showRoundSummary = false;
+      gs.phase = "end";
+    }, totalDelay);
+  } else {
+    // Show the per-round summary so players can see exactly what each operator played.
+    // The summary is cleared when onRoundStart fires for the next round.
+    setTimeout(function () {
+      gs.showRoundSummary = true;
+      gs.turn = data.turn;
     }, totalDelay);
   }
+}
+
+function resetGameState() {
+  gs.logEntries = [];
+  gs.lastRoundResults = [];
+  gs.lastRoundTurn = 0;
+  gs.showRoundSummary = false;
+  gs.finalResults = null;
+  gs.msgText = "";
+  gs.msgKind = "";
+  gs.showWait = false;
+  gs.invalidShake = 0;
+  gs.selected = [];
+  gs.selectedCardIdx = null;
+  gs.locked = false;
+  gs.turn = 1;
+  gs.allScores = [];
+}
+
+export function dismissResults() {
+  gs.showRoundSummary = false;
+}
+
+export function returnToLobby() {
+  destroy();
+  HS.started = false;
+  HS.turn = 1;
+  HS.picks = {};
+  HS.hands = {};
+  HS.scores = {};
+  HS.playerIds = [];
+  HS.playerNames = {};
+  HS.N = 1;
+  mySlot = 0;
+  conns = [];
+  isHost = false;
+  isSolo = false;
+  gs.finalResults = null;
+  gs.phase = "lobby";
+  gs.lobbyPanel = "menu";
+  gs.roomCode = "";
+  gs.joinCodeInput = "";
+  gs.joinStatus = "";
+  gs.playerList = [];
+  gs.playerCount = 1;
+  gs.mySlot = 0;
+  gs.isSolo = false;
+  resetGameState();
+}
+
+export function triggerInvalidShake() {
+  gs.invalidShake = gs.invalidShake + 1;
 }
 
 // ---- Networking ----
@@ -568,11 +718,15 @@ function onMessage(data: unknown, fromSlot: number) {
 
 // ---- Lobby / PeerJS ----
 function updatePlayerList() {
-  gs.playerList = HS.playerIds.map((_, i) => ({
-    slot: i,
-    name: HS.playerNames[i] ?? (i === 0 ? "You (Host)" : "Player " + (i + 1)),
-    color: PLAYER_CSS[i] ?? "#ffffff",
-  }));
+  gs.playerList = HS.playerIds.map((_, i) => {
+    const stored = HS.playerNames[i];
+    const display = i === mySlot ? "You" : (stored ?? "Player " + (i + 1));
+    return {
+      slot: i,
+      name: display + (i === 0 ? " (Host)" : ""),
+      color: PLAYER_CSS[i] ?? "#ffffff",
+    };
+  });
   gs.lobbyStatus = HS.playerIds.length + "/" + MAX_PLAYERS + " operators tuned in.";
 }
 
@@ -609,13 +763,15 @@ export function soloGame() {
   gs.isSolo = true;
   HS.playerIds = ["host", "cpu"];
   HS.scores = { 0: 0, 1: 0 };
-  HS.playerNames = { 0: "You", 1: "CPU" };
+  // Host's stored name is "Host"; the local UI renders "You" for mySlot via slotName().
+  HS.playerNames = { 0: "Host", 1: "CPU" };
   HS.N = 2;
   HS.turn = 1;
   HS.started = true;
   conns = [null, null];
   gs.playerNames = HS.playerNames;
   gs.playerCount = 2;
+  resetGameState();
   startGame();
   hostStartRound();
 }
@@ -630,11 +786,13 @@ export function hostGame() {
   gs.isSolo = false;
   HS.playerIds = ["host"];
   HS.scores = { 0: 0 };
-  HS.playerNames = { 0: "You" };
+  // Host's stored name is "Host"; the local UI renders "You" for mySlot via slotName().
+  HS.playerNames = { 0: "Host" };
   HS.N = 1;
   HS.turn = 1;
   HS.started = false;
   conns = [null];
+  resetGameState();
   gs.lobbyPanel = "waiting";
   updatePlayerList();
 
@@ -714,6 +872,7 @@ export function joinGame() {
   gs.isSolo = false;
   gs.lobbyPanel = "joining";
   gs.joinStatus = "Locking onto " + roomCode + "…";
+  resetGameState();
 
   peer = new Peer();
   peer.on("open", function () {
@@ -759,7 +918,8 @@ export function onPickCard() {
   if (gs.locked || gs.selectedCardIdx == null) return;
   const card = gs.myHand[gs.selectedCardIdx];
   if (!card || !validates(gs.selected, card)) {
-    showMsg("Pattern & frequency mismatch — adjust selection.");
+    showMsg("Pattern & frequency mismatch — adjust selection.", "bad");
+    triggerInvalidShake();
     return;
   }
   gs.locked = true;

--- a/src/routes/games/deconstruct/+page.svelte
+++ b/src/routes/games/deconstruct/+page.svelte
@@ -5,6 +5,7 @@
   import { gs } from "$lib/games/deconstruct/gameState.svelte.js";
   import Scene from "$lib/games/deconstruct/Scene.svelte";
   import { COLORS_CSS, PLAYER_CSS } from "$lib/games/deconstruct/types.js";
+  import type { Card } from "$lib/games/deconstruct/types.js";
   import {
     buildRoomShareUrl,
     clearRoomCodeFromUrl,
@@ -41,6 +42,12 @@
   const onPickCard = () => mod?.onPickCard();
   const onClear = () => mod?.onClear();
   const onPass = () => mod?.onPass();
+  const returnToLobby = () => mod?.returnToLobby();
+  const dismissResults = () => mod?.dismissResults();
+
+  function cardHasPlacement(card: Card): boolean {
+    return mod?.cardHasPlacement(card) ?? true;
+  }
 
   function flashCopyStatus(msg: string): void {
     copyStatus = msg;
@@ -78,6 +85,17 @@
   function slotName(slot: number): string {
     if (slot === gs.mySlot) return "You";
     return gs.playerNames[slot] || (gs.isSolo ? "CPU" : "P" + (slot + 1));
+  }
+
+  function colorName(key: string): string {
+    const names: Record<string, string> = {
+      R: "ALPHA",
+      G: "BETA",
+      B: "GAMMA",
+      Y: "DELTA",
+      P: "EPSILON",
+    };
+    return names[key] ?? key;
   }
 </script>
 
@@ -204,47 +222,126 @@
         // Awaiting other operators&hellip;
       </div>
 
-      <div id="side-panel">
-        <div id="player-hand" class="hand">
-          {#each gs.myHand as card, idx (idx)}
-            {@const mx = Math.max(...card.shape.cells.map((p) => p[0] ?? 0)) + 1}
-            {@const my = Math.max(...card.shape.cells.map((p) => p[1] ?? 0)) + 1}
-            <div
-              class="card{gs.selectedCardIdx === idx ? ' selected' : ''}"
-              style="border-color: {COLORS_CSS[card.color]};"
-              onclick={() => selectCard(idx)}
-              role="button"
-              tabindex="0"
-              onkeydown={(e) => handleCardKeydown(e, idx)}
-            >
-              <div class="card-num">Δ{card.init}</div>
-              <div class="card-label">{card.shape.name}</div>
-              <div class="mini-grid" style="grid-template-columns: repeat({mx}, 12px);">
-                {#each Array.from({ length: my }, (_, i) => i) as dy (dy)}
-                  {#each Array.from({ length: mx }, (_, i) => i) as dx (dx)}
-                    <div
-                      class="mini-dot{card.shape.cells.some((p) => p[0] === dx && p[1] === dy)
-                        ? ' active'
-                        : ''}"
-                      style={card.shape.cells.some((p) => p[0] === dx && p[1] === dy)
-                        ? `background-color: ${COLORS_CSS[card.color]}`
-                        : ""}
-                    ></div>
+      {#key gs.invalidShake}
+        <div id="side-panel" class={gs.invalidShake > 0 ? "shake" : ""}>
+          <div id="player-hand" class="hand">
+            {#each gs.myHand as card, idx (card.init)}
+              {@const mx = Math.max(...card.shape.cells.map((p) => p[0] ?? 0)) + 1}
+              {@const my = Math.max(...card.shape.cells.map((p) => p[1] ?? 0)) + 1}
+              {@const playable = cardHasPlacement(card)}
+              <div
+                class="card{gs.selectedCardIdx === idx ? ' selected' : ''}{playable
+                  ? ''
+                  : ' unplayable'}"
+                style="border-color: {COLORS_CSS[card.color]};"
+                onclick={() => selectCard(idx)}
+                role="button"
+                tabindex="0"
+                title={playable
+                  ? `${card.shape.name} on ${colorName(card.color)}`
+                  : `No valid target for ${colorName(card.color)} on the grid`}
+                aria-disabled={!playable}
+                onkeydown={(e) => handleCardKeydown(e, idx)}
+              >
+                <div class="card-num">Δ{card.init}</div>
+                <div class="card-label">{card.shape.name}</div>
+                <div class="mini-grid" style="grid-template-columns: repeat({mx}, 12px);">
+                  {#each Array.from({ length: my }, (_, i) => i) as dy (dy)}
+                    {#each Array.from({ length: mx }, (_, i) => i) as dx (dx)}
+                      <div
+                        class="mini-dot{card.shape.cells.some((p) => p[0] === dx && p[1] === dy)
+                          ? ' active'
+                          : ''}"
+                        style={card.shape.cells.some((p) => p[0] === dx && p[1] === dy)
+                          ? `background-color: ${COLORS_CSS[card.color]}`
+                          : ""}
+                      ></div>
+                    {/each}
                   {/each}
-                {/each}
+                </div>
+                {#if !playable}
+                  <div class="card-badge">NO MATCH</div>
+                {/if}
               </div>
+            {/each}
+          </div>
+          <div class="btn-group">
+            <button
+              id="resolve-btn"
+              disabled={gs.locked || gs.selectedCardIdx == null || gs.selected.length === 0}
+              onclick={onPickCard}>TRANSMIT</button
+            >
+            <button class="btn-secondary" onclick={onClear}>CLEAR</button>
+            <button class="btn-secondary" onclick={onPass}>HOLD</button>
+          </div>
+        </div>
+      {/key}
+
+      {#if gs.showRoundSummary && gs.lastRoundResults.length > 0}
+        <div class="round-summary" role="dialog" aria-label="Round results">
+          <div class="round-summary-head">
+            // CYCLE {gs.lastRoundTurn} RESULTS
+          </div>
+          <div class="round-summary-body">
+            {#each gs.lastRoundResults as r (r.slot)}
+              <div class="round-row" style="border-left-color: {PLAYER_CSS[r.slot] ?? '#888'};">
+                <span class="round-player" style="color: {PLAYER_CSS[r.slot] ?? '#ccc'};"
+                  >{slotName(r.slot)}</span
+                >
+                <span class="round-play">
+                  {#if r.card}
+                    Δ{r.card.init} · {r.card.shape.name} · {colorName(r.card.color)}
+                  {:else}
+                    held carrier
+                  {/if}
+                </span>
+                <span
+                  class="round-points {r.points > 0
+                    ? 'pts-ok'
+                    : r.card
+                      ? 'pts-bad'
+                      : 'pts-neutral'}"
+                >
+                  {r.points > 0 ? "+" + r.points : r.card ? "0 (lost)" : "—"}
+                </span>
+              </div>
+            {/each}
+          </div>
+          <button class="btn-secondary round-dismiss" onclick={dismissResults}>DISMISS</button>
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  {#if gs.phase === "end" && gs.finalResults}
+    {@const finalScores = [...gs.finalResults.scores].sort((a, b) => b.score - a.score)}
+    <div id="end-screen" role="dialog" aria-label="Final transmission results">
+      <div class="end-box">
+        <h1>// TRANSMISSION CLOSED</h1>
+        <div class="end-winner">
+          {#if gs.finalResults.winnerSlot === -2}
+            Signal split — tied transmission.
+          {:else if gs.finalResults.winnerSlot === gs.mySlot}
+            You intercepted the transmission.
+          {:else}
+            {slotName(gs.finalResults.winnerSlot)} intercepted the transmission.
+          {/if}
+        </div>
+        <div class="end-scores">
+          {#each finalScores as s, i (s.slot)}
+            <div
+              class="end-score-row {i === 0 ? 'top' : ''}"
+              style="border-color: {PLAYER_CSS[s.slot] ?? '#3a3a4a'};"
+            >
+              <span class="end-rank">{i + 1}</span>
+              <span class="end-name" style="color: {PLAYER_CSS[s.slot] ?? '#fff'};"
+                >{slotName(s.slot)}</span
+              >
+              <span class="end-points">{s.score}</span>
             </div>
           {/each}
         </div>
-        <div class="btn-group">
-          <button
-            id="resolve-btn"
-            disabled={gs.locked || gs.selectedCardIdx == null || gs.selected.length === 0}
-            onclick={onPickCard}>TRANSMIT</button
-          >
-          <button class="btn-secondary" onclick={onClear}>CLEAR</button>
-          <button class="btn-secondary" onclick={onPass}>HOLD</button>
-        </div>
+        <button onclick={returnToLobby}>RETURN TO LOBBY</button>
       </div>
     </div>
   {/if}

--- a/src/routes/games/deconstruct/style.css
+++ b/src/routes/games/deconstruct/style.css
@@ -226,6 +226,57 @@
     background: #1f2a38;
     box-shadow: 0 0 12px rgba(3, 218, 198, 0.3);
   }
+  .card.unplayable {
+    opacity: 0.45;
+    filter: grayscale(0.55);
+    cursor: not-allowed;
+  }
+  .card.unplayable:hover {
+    transform: none;
+  }
+  .card-badge {
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    left: 4px;
+    text-align: center;
+    font-size: 8px;
+    letter-spacing: 0.5px;
+    color: var(--red);
+    background: rgba(20, 12, 18, 0.85);
+    padding: 2px 4px;
+    border-radius: 2px;
+    pointer-events: none;
+  }
+  .card {
+    position: relative;
+  }
+
+  /* Shake animation fires each time [data-shake] changes. */
+  @keyframes decon-shake {
+    0%,
+    100% {
+      transform: translateX(-50%) translateY(0);
+    }
+    15% {
+      transform: translateX(calc(-50% - 6px)) translateY(0);
+    }
+    30% {
+      transform: translateX(calc(-50% + 6px)) translateY(0);
+    }
+    45% {
+      transform: translateX(calc(-50% - 4px)) translateY(0);
+    }
+    60% {
+      transform: translateX(calc(-50% + 4px)) translateY(0);
+    }
+    75% {
+      transform: translateX(calc(-50% - 2px)) translateY(0);
+    }
+  }
+  #side-panel.shake {
+    animation: decon-shake 0.42s ease;
+  }
   .card-num {
     font-size: 16px;
     font-weight: bold;
@@ -357,5 +408,147 @@
   }
   #wait-banner.hidden {
     display: none;
+  }
+
+  /* Round results summary (between rounds) */
+  .round-summary {
+    pointer-events: auto;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(16, 16, 24, 0.96);
+    backdrop-filter: blur(12px);
+    border: 1px solid var(--primary);
+    border-radius: 10px;
+    padding: 16px 22px;
+    min-width: 340px;
+    max-width: min(540px, 90vw);
+    box-shadow: 0 0 24px rgba(79, 208, 255, 0.25);
+    z-index: 5;
+  }
+  .round-summary-head {
+    color: var(--primary);
+    font-weight: bold;
+    letter-spacing: 2px;
+    font-size: 0.9rem;
+    text-align: center;
+    margin-bottom: 12px;
+    text-shadow: 0 0 8px rgba(79, 208, 255, 0.35);
+  }
+  .round-summary-body {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 12px;
+  }
+  .round-row {
+    display: grid;
+    grid-template-columns: minmax(70px, auto) 1fr minmax(70px, auto);
+    align-items: center;
+    gap: 12px;
+    padding: 6px 10px;
+    background: #111118;
+    border-left: 3px solid #888;
+    border-radius: 4px;
+    font-size: 12px;
+  }
+  .round-player {
+    font-weight: bold;
+    letter-spacing: 0.5px;
+  }
+  .round-play {
+    opacity: 0.8;
+    font-size: 11px;
+  }
+  .round-points {
+    text-align: right;
+    font-weight: bold;
+    font-size: 13px;
+  }
+  .round-points.pts-ok {
+    color: var(--ok);
+  }
+  .round-points.pts-bad {
+    color: var(--red);
+  }
+  .round-points.pts-neutral {
+    color: #888;
+  }
+  .round-dismiss {
+    display: block;
+    margin: 0 auto;
+  }
+
+  /* End-of-game screen */
+  #end-screen {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(8, 8, 12, 0.92);
+    backdrop-filter: blur(12px);
+  }
+  .end-box {
+    background: var(--surface);
+    border: 1px solid var(--primary);
+    border-radius: 14px;
+    padding: 28px 32px;
+    text-align: center;
+    min-width: 340px;
+    max-width: min(480px, 92vw);
+    box-shadow: 0 0 32px rgba(79, 208, 255, 0.25);
+  }
+  .end-box h1 {
+    color: var(--primary);
+    font-size: 1.2rem;
+    letter-spacing: 2px;
+    margin-bottom: 8px;
+    text-shadow: 0 0 12px rgba(79, 208, 255, 0.4);
+  }
+  .end-winner {
+    color: var(--ok);
+    font-size: 0.95rem;
+    margin-bottom: 20px;
+  }
+  .end-scores {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 22px;
+    text-align: left;
+  }
+  .end-score-row {
+    display: grid;
+    grid-template-columns: 28px 1fr auto;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    background: #111118;
+    border: 1px solid #3a3a4a;
+    border-radius: 6px;
+    font-size: 14px;
+  }
+  .end-score-row.top {
+    background: #1f2a38;
+    box-shadow: 0 0 12px rgba(3, 218, 198, 0.2);
+  }
+  .end-rank {
+    color: var(--primary);
+    font-weight: bold;
+    text-align: center;
+  }
+  .end-name {
+    font-weight: bold;
+    letter-spacing: 0.5px;
+  }
+  .end-points {
+    font-weight: bold;
+    font-size: 1rem;
   }
 }


### PR DESCRIPTION
Closes #48.

## Summary
- Dedup duplicate "You" label in the scoreboard/lobby (host is now "Host"; local UI still renders "You" via `slotName`).
- Unplayable cards are greyed with a "NO MATCH" badge; TRANSMIT on an invalid card triggers a shake + red message.
- Stable hands across rounds (`refillHand` preserves unplayed cards; only played/failed cards rotate).
- Proper end-of-game transition to a final results screen with podium + "Return to Lobby"; driven by broadcast `gameOver`.
- Scoring bug fix: validation now uses the authoritative post-removal grid (`validatesIn`/`topColorIn`), so a higher-delta interfered play scores 0.
- Round-results modal shows each operator's played card (Δ, shape, color) and per-round points.

## Test plan
- [ ] Play a local 2-operator game through to end screen; confirm only one "You" is shown.
- [ ] Attempt to play a mismatched card; see NO MATCH feedback and shake on TRANSMIT.
- [ ] Play several rounds; verify unplayed cards persist between rounds.
- [ ] Contrive an interference scenario where delta(A) < delta(B); verify B scores 0 for the interfered play.
- [ ] Inspect round-summary modal shows all operators' cards and points.