### PR TITLE
Signal Cross follow-up fixes (#49)

### DIFF
--- a/src/lib/games/signal-cross/data.ts
+++ b/src/lib/games/signal-cross/data.ts
@@ -211,6 +211,51 @@ export const CORRECT: Record<string, DialogLine[]> = {
     { s: "pope", t: "She hissed at a cardinal." },
     { s: "quack", t: "That's just swans. Bless you. Bye." },
   ],
+  "henderson>quack": [
+    { s: "henderson", t: "Doctor! The finch is — is it MEANT to look like that?" },
+    { s: "quack", t: "Ma'am, which finch." },
+    { s: "henderson", t: "The one on the sill. He's sideways." },
+    { s: "quack", t: "I'll stop by after six. Good evening." },
+  ],
+  "butcher>dog": [
+    { s: "butcher", t: "Buster. Bone's on the counter. Come get it." },
+    { s: "dog", t: "(delighted huff)" },
+    { s: "butcher", t: "…how are you even on this line." },
+    { s: "dog", t: "(tail thumping wood)" },
+  ],
+  "mayor>henderson": [
+    { s: "mayor", t: "Edna. Returning your call. The streetlight?" },
+    { s: "henderson", t: "Also the SQUIRRELS, mayor. The SQUIRRELS." },
+    { s: "mayor", t: "…I'll form a committee. Evening." },
+  ],
+  "spy>butcher": [
+    { s: "spy", t: "Butcher. Package arrives 0400. Triple-wrapped." },
+    { s: "butcher", t: "Chuck or brisket, pal." },
+    { s: "spy", t: "…chuck. Confirmed. Out." },
+  ],
+  "mom>butcher": [
+    { s: "mom", t: "Marty dear, I need a roast for Sunday." },
+    { s: "butcher", t: "Three pounds, bone in. I'll set it aside." },
+    { s: "mom", t: "You're a saint, Marty." },
+    { s: "butcher", t: "I'm a butcher. Goodbye." },
+  ],
+  "traveler>butcher": [
+    { s: "traveler", t: "Butcher — from February. DO NOT stock the clams Thursday." },
+    { s: "butcher", t: "Pal, it's TUESDAY." },
+    { s: "traveler", t: "I know. I'm ahead. Out." },
+  ],
+  "ghost>mom": [
+    { s: "ghost", t: "MMMOOOOTHEEEERR……" },
+    { s: "mom", t: "Derek??" },
+    { s: "ghost", t: "N̸O̸ — CAAARL. FROM THE BASEMENT." },
+    { s: "mom", t: "Carl sweetie did you eat." },
+    { s: "ghost", t: "…nooOOOoo……" },
+  ],
+  "moon>henderson": [
+    { s: "moon", t: "Edna. It is I. The Moon." },
+    { s: "henderson", t: "I've got a LIGHT on the corner, Luna." },
+    { s: "moon", t: "That's… not me. Goodnight." },
+  ],
 };
 
 export const WRONG: Record<string, DialogLine[]> = {
@@ -297,6 +342,46 @@ export const WRONG: Record<string, DialogLine[]> = {
     { s: "spy", t: "…the asset is a pork loin?" },
     { s: "butcher", t: "It can be. Buh-bye." },
   ],
+  "ghost>mayor": [
+    { s: "ghost", t: "MAYOR……… PIBBLEEEEEY……" },
+    { s: "mayor", t: "Sir, my re-election is on Tuesday." },
+    { s: "ghost", t: "I VOTE TWICE." },
+    { s: "mayor", t: "…noted. Goodbye." },
+  ],
+  "pope>mom": [
+    { s: "pope", t: "Madam. We are calling from the Holy See." },
+    { s: "mom", t: "Is this about DEREK." },
+    { s: "pope", t: "…we, regrettably, do not know a Derek." },
+    { s: "mom", t: "Bless you anyway. Goodbye." },
+  ],
+  "mom>mayor": [
+    { s: "mom", t: "Mayor. About my Derek." },
+    { s: "mayor", t: "Ma'am, this is the mayor's line, not the—" },
+    { s: "mom", t: "He's a SPY, mayor. A GOOD BOY spy." },
+    { s: "mayor", t: "…that's classified. Goodbye." },
+  ],
+  "dog>quack": [
+    { s: "dog", t: "Woof." },
+    { s: "quack", t: "Buster. Is it the paw again." },
+    { s: "dog", t: "(whimper)" },
+    { s: "quack", t: "I'll come by. Keep it up. Bye." },
+  ],
+  "elvis>butcher": [
+    { s: "elvis", t: "Hound dog needs a BONE, partner." },
+    { s: "butcher", t: "Sir, we close at six." },
+    { s: "elvis", t: "Thank you, thank you very much. G'night." },
+  ],
+  "traveler>mom": [
+    { s: "traveler", t: "Ma'am — from NEXT Monday. Don't answer the door at 3pm." },
+    { s: "mom", t: "Is this DEREK." },
+    { s: "traveler", t: "…temporally speaking, no. Out." },
+  ],
+  "henderson>mom": [
+    { s: "henderson", t: "Mother of Derek? This is Edna." },
+    { s: "mom", t: "Oh Edna is he WITH you?" },
+    { s: "henderson", t: "No dear. Wrong number. Ta-ta." },
+    { s: "mom", t: "(sighs)" },
+  ],
 };
 
 export const WRONG_FALLBACK_A = [
@@ -305,6 +390,11 @@ export const WRONG_FALLBACK_A = [
   "[EXPECT], is that you?",
   "Put [EXPECT] on.",
   "This is about [EXPECT].",
+  "Hi, I'm trying to reach [EXPECT].",
+  "Operator said this was [EXPECT]'s line.",
+  "Oh good, [EXPECT]! Finally.",
+  "[EXPECT]? It's urgent.",
+  "Sorry — connection's bad. [EXPECT]?",
 ];
 
 export const WRONG_FALLBACK_B = [
@@ -313,6 +403,11 @@ export const WRONG_FALLBACK_B = [
   "Negative. [ACTUAL] speaking.",
   "You've got [ACTUAL]. Who is this?",
   "[ACTUAL] here. Who are you calling for?",
+  "…this is [ACTUAL]. Who?",
+  "Ma'am, this is [ACTUAL]'s phone.",
+  "I am [ACTUAL]. You have the wrong line.",
+  "[ACTUAL] residence. You must be crossed.",
+  "Hello? Yeah, [ACTUAL]. Not who you wanted.",
 ];
 
 export const WRONG_FALLBACK_C = [
@@ -320,6 +415,44 @@ export const WRONG_FALLBACK_C = [
   "Nevermind. Bye.",
   "Forget I called. Bye.",
   "Hello? Wait no. Goodbye.",
+  "Gosh — OPERATOR get it right. Bye.",
+  "I'm hanging up. Sorry.",
+  "Tell the operator they're CROSSED.",
+  "Well this is awkward. Bye.",
+  "My mistake. Have a good one.",
+  "Drat. Back to the directory. Click.",
+];
+
+export const CORRECT_FALLBACK_OPEN = [
+  "Hello, [ACTUAL]?",
+  "[ACTUAL]? It's me.",
+  "Hi [ACTUAL], quick one.",
+  "[ACTUAL] — sorry to ring late.",
+  "That you, [ACTUAL]?",
+];
+
+export const CORRECT_FALLBACK_REPLY = [
+  "Speaking.",
+  "Yes, this is [ACTUAL].",
+  "Go ahead.",
+  "I hear you.",
+  "[ACTUAL] here.",
+];
+
+export const CORRECT_FALLBACK_MID = [
+  "Just a quick one.",
+  "Won't keep you long.",
+  "Real fast, then I'll go.",
+  "Got a second?",
+  "Listen, about that thing.",
+];
+
+export const CORRECT_FALLBACK_CLOSE = [
+  "Understood. Goodbye.",
+  "Got it. Bye now.",
+  "All right. Take care.",
+  "Thank you. Goodnight.",
+  "Right then. Bye.",
 ];
 
 export const CLOSERS = [
@@ -327,6 +460,10 @@ export const CLOSERS = [
   "*click — receiver set down*",
   "*tone — call ended*",
   "*click — both hung up*",
+  "*soft click — the line rests*",
+  "*dial tone returns*",
+  "*kachunk — the plug pulls free*",
+  "*click — silence*",
 ];
 
 export const PLAYER_COLORS = [

--- a/src/lib/games/signal-cross/main.ts
+++ b/src/lib/games/signal-cross/main.ts
@@ -12,6 +12,10 @@ import {
   CHARS,
   CLOSERS,
   CORRECT,
+  CORRECT_FALLBACK_CLOSE,
+  CORRECT_FALLBACK_MID,
+  CORRECT_FALLBACK_OPEN,
+  CORRECT_FALLBACK_REPLY,
   DIRTY_SLIP_CHANCE,
   FORGED_NAME_CHANCE,
   LEVELS,
@@ -397,6 +401,19 @@ export function mount(callbacks: Signal1Callbacks): Signal1Controls {
     else if (msg.type === "verifyDecision") handleVerifyDecision(p, msg.ticketId, msg.decision);
     else if (msg.type === "stamp") handleStamp(p, msg.ticketId, msg.decision);
     else if (msg.type === "agencyAnswer") handleAgencyAnswer(p, msg.ticketId, msg.choiceIdx);
+    else if (msg.type === "agencyAttend") handleAgencyAttend(p, msg.ticketId, msg.attending);
+  }
+
+  function handleAgencyAttend(p: Player, ticketId: number, attending: boolean): void {
+    const ticket = state.tickets.find(
+      (t) => t.id === ticketId && t.status === "ringing" && t.kind === "agency"
+    );
+    if (!ticket) return;
+    const set = new Set(ticket.agencyAttending);
+    if (attending) set.add(p.id);
+    else set.delete(p.id);
+    ticket.agencyAttending = [...set];
+    broadcastState();
   }
 
   function handleSelect(p: Player, plugId: string): void {
@@ -685,6 +702,7 @@ export function mount(callbacks: Signal1Callbacks): Signal1Controls {
       reviewer: null,
       agencyQ: null,
       agencyPickedBy: null,
+      agencyAttending: [],
     });
     broadcastState();
     broadcastEvent({ type: "ring" });
@@ -710,6 +728,7 @@ export function mount(callbacks: Signal1Callbacks): Signal1Controls {
       reviewer: null,
       agencyQ: q,
       agencyPickedBy: null,
+      agencyAttending: [],
     });
     broadcastState();
     broadcastEvent({ type: "agencyRing" });
@@ -735,6 +754,13 @@ export function mount(callbacks: Signal1Callbacks): Signal1Controls {
       "whoRoutedByOp",
       "whoCutEarly",
       "lastCallerTo",
+      "routedCount",
+      "topOperator",
+      "opWithMostChaos",
+      "lastCallerOverall",
+      "everCalled",
+      "opRoutedCount",
+      "timeoutCount",
     ] satisfies readonly string[];
     for (const type of shuffle(eventTypes)) {
       if (type === "whoSpokeTo") {
@@ -827,6 +853,141 @@ export function mount(callbacks: Signal1Callbacks): Signal1Controls {
           correctIdx: choices.findIndex((c) => c.tag === callerId),
         };
       }
+      if (type === "routedCount") {
+        const count = state.correctCount;
+        const opts = new Set([count, Math.max(0, count - 1), count + 1, count + 2]);
+        const arr = shuffle([...opts]).slice(0, 4);
+        while (arr.length < 4) arr.push((arr[arr.length - 1] ?? 0) + 1);
+        const choices = arr.map((n) => ({ label: String(n), tag: n }));
+        return {
+          text: `"Confirm tonight's CLEAN route count for the record."`,
+          choices,
+          correctIdx: choices.findIndex((c) => c.tag === count),
+        };
+      }
+      if (type === "topOperator") {
+        const tally = new Map<string, number>();
+        for (const e of ended) {
+          if (e.result === "routed") tally.set(e.byPlayer, (tally.get(e.byPlayer) ?? 0) + 1);
+        }
+        if (!tally.size) continue;
+        let topId: string | null = null;
+        let topN = -1;
+        for (const [id, n] of tally) {
+          if (n > topN) {
+            topN = n;
+            topId = id;
+          }
+        }
+        if (!topId) continue;
+        const others = state.players.filter((p) => p.id !== topId);
+        if (others.length < 2) continue;
+        shuffle(others);
+        const distractors = others.slice(0, Math.min(3, others.length));
+        const all = shuffle([topId, ...distractors.map((p) => p.id)]);
+        const choices = all.map((id) => {
+          const pl = state.players.find((p) => p.id === id);
+          return { label: pl?.name ?? id, tag: id };
+        });
+        return {
+          text: `"Which operator has the MOST clean routes tonight?"`,
+          choices,
+          correctIdx: choices.findIndex((c) => c.tag === topId),
+        };
+      }
+      if (type === "opWithMostChaos") {
+        const tally = new Map<string, number>();
+        for (const e of ended) {
+          if (e.result === "chaos") tally.set(e.byPlayer, (tally.get(e.byPlayer) ?? 0) + 1);
+        }
+        if (!tally.size) continue;
+        let topId: string | null = null;
+        let topN = -1;
+        for (const [id, n] of tally) {
+          if (n > topN) {
+            topN = n;
+            topId = id;
+          }
+        }
+        if (!topId) continue;
+        const others = state.players.filter((p) => p.id !== topId);
+        if (others.length < 2) continue;
+        shuffle(others);
+        const distractors = others.slice(0, Math.min(3, others.length));
+        const all = shuffle([topId, ...distractors.map((p) => p.id)]);
+        const choices = all.map((id) => {
+          const pl = state.players.find((p) => p.id === id);
+          return { label: pl?.name ?? id, tag: id };
+        });
+        return {
+          text: `"Between you and me — who crossed the MOST wires tonight?"`,
+          choices,
+          correctIdx: choices.findIndex((c) => c.tag === topId),
+        };
+      }
+      if (type === "lastCallerOverall") {
+        const ref = ended[0];
+        if (!ref) continue;
+        const callerId = ref.from;
+        if (!CHARS[callerId]) continue;
+        const distractors = pickChars([callerId], 3);
+        if (distractors.length < 2) continue;
+        const choices = shuffle([callerId, ...distractors]).map((id) => ({
+          label: CHARS[id]?.name ?? id,
+          tag: id,
+        }));
+        return {
+          text: `"Who was the LAST caller to disconnect tonight?"`,
+          choices,
+          correctIdx: choices.findIndex((c) => c.tag === callerId),
+        };
+      }
+      if (type === "everCalled") {
+        const calledSet = new Set<string>();
+        for (const e of ended) calledSet.add(e.from);
+        if (!calledSet.size) continue;
+        const notCalled = lvl.chars.filter((c) => !calledSet.has(c) && c !== "agency");
+        if (notCalled.length < 1) continue;
+        const pickNotCalled = notCalled[Math.floor(Math.random() * notCalled.length)];
+        if (!pickNotCalled) continue;
+        const called = shuffle([...calledSet]).slice(0, 3);
+        if (called.length < 2) continue;
+        const all = shuffle([pickNotCalled, ...called]);
+        const choices = all.map((id) => ({ label: CHARS[id]?.name ?? id, tag: id }));
+        return {
+          text: `"Which of these has NOT called in tonight?"`,
+          choices,
+          correctIdx: choices.findIndex((c) => c.tag === pickNotCalled),
+        };
+      }
+      if (type === "opRoutedCount") {
+        if (state.players.length < 1) continue;
+        const op = state.players[Math.floor(Math.random() * state.players.length)];
+        if (!op) continue;
+        const count = ended.filter((e) => e.byPlayer === op.id && e.result === "routed").length;
+        const opts = new Set([count, Math.max(0, count - 1), count + 1, count + 2]);
+        const arr = shuffle([...opts]).slice(0, 4);
+        while (arr.length < 4) arr.push((arr[arr.length - 1] ?? 0) + 1);
+        const choices = arr.map((n) => ({ label: String(n), tag: n }));
+        return {
+          text: `"${op.name} — how many CLEAN routes is that for you tonight?"`,
+          choices,
+          correctIdx: choices.findIndex((c) => c.tag === count),
+        };
+      }
+      if (type === "timeoutCount") {
+        const count = state.timeoutCount;
+        if (count === 0) continue;
+        const opts = new Set([count, Math.max(0, count - 1), count + 1, count + 2]);
+        const arr = shuffle([...opts]).slice(0, 4);
+        while (arr.length < 4) arr.push((arr[arr.length - 1] ?? 0) + 1);
+        const choices = arr.map((n) => ({ label: String(n), tag: n }));
+        return {
+          text: `"How many callers went UNANSWERED to timeout?"`,
+          choices,
+          correctIdx: choices.findIndex((c) => c.tag === count),
+        };
+      }
     }
     return null;
   }
@@ -869,12 +1030,18 @@ export function mount(callbacks: Signal1Callbacks): Signal1Controls {
     const key = `${fromId}>${actualId}`;
     let base: DialogLine[];
     if (correct) {
-      base = CORRECT[key] ?? [
-        { s: fromId, t: `Hello, ${CHARS[actualId]?.name ?? actualId}?` },
-        { s: actualId, t: "Speaking." },
-        { s: fromId, t: "Just a quick one." },
-        { s: actualId, t: "Understood. Goodbye." },
-      ];
+      const baseCorrect = CORRECT[key];
+      if (baseCorrect && Array.isArray(baseCorrect)) {
+        base = baseCorrect;
+      } else {
+        const actualName = CHARS[actualId]?.name ?? actualId;
+        base = [
+          { s: fromId, t: pick(CORRECT_FALLBACK_OPEN).replace("[ACTUAL]", actualName) },
+          { s: actualId, t: pick(CORRECT_FALLBACK_REPLY).replace("[ACTUAL]", actualName) },
+          { s: fromId, t: pick(CORRECT_FALLBACK_MID) },
+          { s: actualId, t: pick(CORRECT_FALLBACK_CLOSE) },
+        ];
+      }
     } else {
       const wrongLines = WRONG[key];
       if (wrongLines && Array.isArray(wrongLines)) {

--- a/src/lib/games/signal-cross/types.ts
+++ b/src/lib/games/signal-cross/types.ts
@@ -51,6 +51,8 @@ export type Ticket = {
   reviewer: string | null;
   agencyQ: AgencyQuestion | null;
   agencyPickedBy: string | null;
+  /** Players who currently have the agency dossier open (on the line). */
+  agencyAttending: string[];
 };
 
 export type Player = {
@@ -137,7 +139,8 @@ export type ActionMsg =
   | { type: "disconnect"; ticketId: number }
   | { type: "verifyDecision"; ticketId: number; decision: "approve" | "deny" | "cancel" }
   | { type: "stamp"; ticketId: number; decision: "approve" | "deny" }
-  | { type: "agencyAnswer"; ticketId: number; choiceIdx: number };
+  | { type: "agencyAnswer"; ticketId: number; choiceIdx: number }
+  | { type: "agencyAttend"; ticketId: number; attending: boolean };
 
 export interface Signal1Callbacks {
   onSnapshot(snapshot: GameSnapshot): void;

--- a/src/routes/games/signal-cross/+page.svelte
+++ b/src/routes/games/signal-cross/+page.svelte
@@ -79,6 +79,59 @@
   let slipModalTicketId = $state<number | null>(null);
   let slipModalRole = $state<"verify" | "supervisor">("verify");
   let agencyModalTicketId = $state<number | null>(null);
+  let tutorialOpen = $state(false);
+  let tutorialStep = $state(0);
+  const TUTORIAL_FLAG_KEY = "signal-cross:tutorial-seen-v1";
+
+  const TUTORIAL_STEPS: { title: string; body: string }[] = [
+    {
+      title: "THE BOARD",
+      body:
+        "Bell Exchange #47. Callers come in on the left plug, recipients on the right. " +
+        "A red, flashing plug is RINGING. Connect them before it times out.",
+    },
+    {
+      title: "PATCHING A CALL",
+      body:
+        "Click the ringing caller plug, THEN click the plug they want to reach. " +
+        "A cable drops — their conversation plays out in the CALL LOG.",
+    },
+    {
+      title: "DISCONNECT",
+      body:
+        "When you see the *click* line, the call is DONE. Click the live plug (or cable) to pull out. " +
+        "Pull too EARLY and the crew takes a penalty. Leave them too long and new callers stack up.",
+    },
+    {
+      title: "THE AGENCY",
+      body:
+        "A red encrypted ticket will appear in INCOMING. ANY operator can click it to answer. " +
+        "The question is about what JUST happened on the board — watch the Call Log. " +
+        "Wrong answer = big penalty.",
+    },
+    {
+      title: "VERIFY MODE",
+      body:
+        "Every call comes with a paper SLIP. Before patching, OPEN the slip and compare it " +
+        "against the INCOMING ticket (caller + intended recipient). Mismatched names, " +
+        "forged signatures, or ⚠ FLAGGED lines → DENY. Correct slip → APPROVE, then patch.",
+    },
+    {
+      title: "SUPERVISOR MODE",
+      body:
+        "One operator plays SUPERVISOR — no cables, only a stamp. " +
+        "Incoming calls sit in limbo until the supervisor opens the slip, compares it " +
+        "to the OPERATOR'S BOARD panel, and STAMPS approve or deny. " +
+        "Patchers can only route calls the supervisor approved.",
+    },
+    {
+      title: "GOOD SHIFT",
+      body:
+        "Keep correct routes above the goal. Crossed wires give small CHAOS points but no progress. " +
+        "Pulling early, timing out, or answering The Agency wrong hurts the penalty column. " +
+        "Press [?] at any time to see this again.",
+    },
+  ];
 
   let floaterSeq = 0;
   let toastHandle: ReturnType<typeof setTimeout> | null = null;
@@ -317,6 +370,15 @@
     };
     rafId = requestAnimationFrame(step);
 
+    try {
+      if (!localStorage.getItem(TUTORIAL_FLAG_KEY)) {
+        tutorialOpen = true;
+        tutorialStep = 0;
+      }
+    } catch {
+      /* ignore storage errors */
+    }
+
     window.addEventListener("keydown", onKeyDown);
     window.addEventListener("contextmenu", onContextMenu);
 
@@ -368,6 +430,25 @@
     const t = agencyTicket;
     if (!t || t.status !== "ringing" || t.agencyPickedBy) {
       agencyModalTicketId = null;
+    }
+  });
+
+  // Broadcast attendance on the agency call whenever the modal opens/closes.
+  let lastAttendedTicketId: number | null = null;
+  $effect(() => {
+    const id = agencyModalTicketId;
+    if (id !== lastAttendedTicketId) {
+      if (lastAttendedTicketId != null) {
+        controls?.sendAction({
+          type: "agencyAttend",
+          ticketId: lastAttendedTicketId,
+          attending: false,
+        });
+      }
+      if (id != null) {
+        controls?.sendAction({ type: "agencyAttend", ticketId: id, attending: true });
+      }
+      lastAttendedTicketId = id;
     }
   });
 
@@ -452,16 +533,10 @@
 
   function ticketRequest(t: Ticket): { name: string; emoji: string } {
     const to = t.to ? CHARS[t.to] : null;
-    const slip = t.slip;
-    const showSlipPreview =
-      snapshot.gameMode === "supervisor" ||
-      (snapshot.gameMode === "verify" && t.approval !== "approved");
-    const name = showSlipPreview && slip ? slip.requestName : (to?.name ?? "?");
-    const emoji =
-      showSlipPreview && slip
-        ? (CHARS[slip.requestId]?.emoji ?? to?.emoji ?? "?")
-        : (to?.emoji ?? "?");
-    return { name, emoji };
+    // Incoming tickets always show the TRUE intended recipient (from the call record).
+    // The slip modal shows what paperwork says, so slip mismatches are visible in the modal
+    // compare panel. Patchers can always trust what's shown on the board.
+    return { name: to?.name ?? "?", emoji: to?.emoji ?? "?" };
   }
 
   function logBadge(entry: LogEntry): { cls: string; text: string } {
@@ -600,7 +675,20 @@
   }
 
   function onKeyDown(e: KeyboardEvent): void {
+    if (e.key === "?" || (e.key === "/" && e.shiftKey)) {
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag !== "INPUT" && tag !== "TEXTAREA" && tag !== "SELECT") {
+        e.preventDefault();
+        openTutorial();
+        return;
+      }
+    }
     if (e.key !== "Escape") return;
+    if (tutorialOpen) {
+      closeTutorial();
+      return;
+    }
     if (slipModalTicketId != null) {
       onSlipCancel();
       return;
@@ -612,6 +700,32 @@
     if (snapshot.phase === "playing" && me?.selected) {
       controls?.sendAction({ type: "deselect" });
     }
+  }
+
+  function openTutorial(): void {
+    tutorialOpen = true;
+    tutorialStep = 0;
+  }
+
+  function closeTutorial(): void {
+    tutorialOpen = false;
+    try {
+      localStorage.setItem(TUTORIAL_FLAG_KEY, "1");
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function nextTutorial(): void {
+    if (tutorialStep < TUTORIAL_STEPS.length - 1) {
+      tutorialStep++;
+    } else {
+      closeTutorial();
+    }
+  }
+
+  function prevTutorial(): void {
+    if (tutorialStep > 0) tutorialStep--;
   }
 
   function autoFocus(node: HTMLElement): void {
@@ -639,6 +753,16 @@
 
 <div class="signal-cross-page">
   <div class="scanlines"></div>
+
+  <button
+    class="help-fab"
+    type="button"
+    aria-label="Show how to play"
+    title="How to play (?)"
+    onclick={openTutorial}
+  >
+    ?
+  </button>
 
   {#if screen === "title"}
     <div id="title-screen" class="screen active">
@@ -810,10 +934,24 @@
       </header>
 
       <section class="switchboard">
-        <div class="panel-label">EXCHANGE 47</div>
+        <div class="panel-label">EXCHANGE 47 — {snapshot.levelTitle}</div>
+        <div class="shift-briefing">
+          <div class="shift-briefing-sub">{snapshot.levelSubtitle}</div>
+          <div class="shift-briefing-tips">
+            <span>◆ CLICK ringing plug, then recipient</span>
+            <span>◆ CLICK live plug/cable to hang up AFTER *click*</span>
+            <span>◆ PRESS ? for tutorial</span>
+          </div>
+        </div>
         {#if lvl}
-          {@const cols = lvl.chars.length <= 6 ? 3 : 4}
-          <div class="board" style:grid-template-columns="repeat({cols}, 92px)">
+          {@const n = lvl.chars.length}
+          {@const cols = n <= 6 ? 3 : n <= 9 ? 3 : 4}
+          {@const plugSize = n <= 6 ? 140 : n <= 9 ? 118 : 96}
+          <div
+            class="board"
+            style:grid-template-columns="repeat({cols}, {plugSize}px)"
+            style:--plug-size="{plugSize}px"
+          >
             {#each lvl.chars as id (id)}
               {@const status = plugStatus(id)}
               {@const c = CHARS[id]}
@@ -882,6 +1020,17 @@
                 <div class="agency-row">CHECK-IN CALL</div>
                 <div class="row"><span class="emoji">☎</span><b>ENCRYPTED LINE</b></div>
                 <div class="agency-row mono">CLICK TO ANSWER</div>
+                <div class="attend-row">
+                  {#each snapshot.players as p (p.id)}
+                    {@const onLine = t.agencyAttending.includes(p.id)}
+                    <span
+                      class="attend-dot"
+                      class:on={onLine}
+                      style:--dotColor={p.color}
+                      title="{p.name}: {onLine ? 'ON THE LINE' : 'not answering'}"
+                    ></span>
+                  {/each}
+                </div>
                 <div class="ring-bar">
                   <div class="ring-bar-fill" style:width="{ringBarPct(t)}%"></div>
                 </div>
@@ -1070,6 +1219,12 @@
 
       {#if slipTicket && slipTicket.slip}
         {@const slip = slipTicket.slip}
+        {@const trueCallerName = CHARS[slipTicket.from]?.name ?? slipTicket.from}
+        {@const trueRequestName = slipTicket.to
+          ? (CHARS[slipTicket.to]?.name ?? slipTicket.to)
+          : "?"}
+        {@const callerMismatch = slip.callerName !== trueCallerName}
+        {@const requestMismatch = slip.requestId !== slipTicket.to}
         <div
           class="slip-modal"
           role="dialog"
@@ -1083,22 +1238,44 @@
               <span>#{slip.slipNum}</span>
             </div>
             <div class="slip-body">
-              <div class="slip-row">
+              <div class="slip-row" class:slip-row-mismatch={callerMismatch}>
                 <span class="slip-k">CALLER</span><b>{slip.callerName}</b>
               </div>
               <div class="slip-row">
                 <span class="slip-k">LINE</span><b>{slip.line}</b>
               </div>
-              <div class="slip-row">
+              <div class="slip-row" class:slip-row-mismatch={requestMismatch}>
                 <span class="slip-k">REQUESTS</span><b>{slip.requestName}</b>
               </div>
               {#if slip.flagged}
-                <div class="slip-flag">⚠ FLAGGED LINE</div>
+                <div class="slip-flag">⚠ FLAGGED LINE — RESTRICTED PARTY</div>
               {/if}
+              <div class="slip-compare">
+                <div class="slip-compare-head">
+                  {slipModalRole === "supervisor"
+                    ? "OPERATOR'S BOARD SAYS"
+                    : "RINGING IN RIGHT NOW"}
+                </div>
+                <div class="slip-row" class:slip-row-mismatch={callerMismatch}>
+                  <span class="slip-k">CALLER</span>
+                  <b>
+                    {CHARS[slipTicket.from]?.emoji ?? ""}
+                    {trueCallerName}
+                  </b>
+                </div>
+                <div class="slip-row" class:slip-row-mismatch={requestMismatch}>
+                  <span class="slip-k">DIALED FOR</span>
+                  <b>
+                    {slipTicket.to ? (CHARS[slipTicket.to]?.emoji ?? "") : ""}
+                    {trueRequestName}
+                  </b>
+                </div>
+                <div class="slip-row">
+                  <span class="slip-k">NOTE</span><b>{slipTicket.note || "—"}</b>
+                </div>
+              </div>
               <div class="slip-hint">
-                {slipModalRole === "supervisor"
-                  ? "Cross-check against INCOMING. Stamp carefully."
-                  : "Double-check caller's request. Approve or deny."}
+                Slip mismatch OR ⚠ flagged line → DENY. Clean slip → APPROVE.
               </div>
             </div>
             <div class="slip-actions">
@@ -1131,12 +1308,65 @@
                 </button>
               {/each}
             </div>
+            <div class="agency-attend">
+              <span class="agency-attend-label">ON THE LINE</span>
+              <div class="agency-attend-list">
+                {#each snapshot.players as p (p.id)}
+                  {@const onLine = agencyTicket.agencyAttending.includes(p.id)}
+                  <div class="agency-attend-op" class:on={onLine}>
+                    <span class="dot" style:background={p.color} style:color={p.color}></span>
+                    <span class="name">{p.name}</span>
+                    <span class="state">{onLine ? "ANSWERED" : "ringing..."}</span>
+                  </div>
+                {/each}
+              </div>
+            </div>
             <div class="agency-timer">
               <div id="agency-timer-fill" style:width="{agencyTimerPct(agencyTicket)}%"></div>
             </div>
+            <button class="mini-btn agency-leave" onclick={() => (agencyModalTicketId = null)}>
+              HANG UP (ESC)
+            </button>
           </div>
         </div>
       {/if}
+    </div>
+  {/if}
+
+  {#if tutorialOpen}
+    {@const step = TUTORIAL_STEPS[tutorialStep]}
+    <div
+      class="tutorial-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tutorial-heading"
+      use:autoFocus
+    >
+      <div class="tutorial-card">
+        <div class="tutorial-head">
+          <span class="tutorial-tag">HOW TO RUN THE BOARD</span>
+          <span class="tutorial-progress">
+            {tutorialStep + 1} / {TUTORIAL_STEPS.length}
+          </span>
+        </div>
+        <h3 id="tutorial-heading" class="tutorial-title">{step?.title ?? ""}</h3>
+        <p class="tutorial-body">{step?.body ?? ""}</p>
+        <div class="tutorial-dots">
+          {#each TUTORIAL_STEPS as step, i (i)}
+            <span class="tutorial-dot" class:active={i === tutorialStep} aria-label={step.title}
+            ></span>
+          {/each}
+        </div>
+        <div class="tutorial-actions">
+          <button class="mini-btn" disabled={tutorialStep === 0} onclick={prevTutorial}>
+            BACK
+          </button>
+          <button class="mini-btn" onclick={closeTutorial}>SKIP</button>
+          <button class="big-btn" onclick={nextTutorial}>
+            {tutorialStep === TUTORIAL_STEPS.length - 1 ? "GOT IT ▸" : "NEXT ▸"}
+          </button>
+        </div>
+      </div>
     </div>
   {/if}
 

--- a/src/routes/games/signal-cross/styles.css
+++ b/src/routes/games/signal-cross/styles.css
@@ -477,6 +477,42 @@
     letter-spacing: 0.5em;
     color: var(--brass);
     opacity: 0.8;
+    white-space: nowrap;
+  }
+  .shift-briefing {
+    position: absolute;
+    bottom: 22px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    max-width: 92%;
+    pointer-events: none;
+    text-align: center;
+  }
+  .shift-briefing-sub {
+    font-size: 11px;
+    letter-spacing: 0.2em;
+    color: var(--brass);
+    text-transform: uppercase;
+    opacity: 0.85;
+    font-style: italic;
+  }
+  .shift-briefing-tips {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+    justify-content: center;
+    font-size: 9px;
+    letter-spacing: 0.22em;
+    color: var(--cream);
+    opacity: 0.55;
+    text-transform: uppercase;
+  }
+  .shift-briefing-tips span {
+    white-space: nowrap;
   }
   .panel-screws {
     position: absolute;
@@ -510,19 +546,19 @@
 
   .board {
     display: grid;
-    gap: 14px;
+    gap: 18px;
     height: 100%;
     align-content: center;
     justify-content: center;
   }
   .plug {
-    width: 92px;
-    height: 106px;
+    width: var(--plug-size, 92px);
+    height: calc(var(--plug-size, 92px) * 1.18);
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-    padding: 6px 4px 4px;
+    padding: 8px 4px 6px;
     cursor: pointer;
     background: linear-gradient(180deg, #2a1a0c, #140a04);
     border: 2px solid var(--brass-deep);
@@ -624,13 +660,13 @@
   }
 
   .plug .bulb {
-    width: 12px;
-    height: 12px;
+    width: 14px;
+    height: 14px;
     border-radius: 50%;
     background: #2a1607;
     border: 1px solid #0a0503;
     box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.8);
-    margin-bottom: 2px;
+    margin-bottom: 4px;
   }
   .plug.ringing .bulb {
     background: var(--red);
@@ -639,25 +675,25 @@
       inset 0 0 2px rgba(255, 255, 255, 0.4);
   }
   .plug .jack {
-    width: 20px;
-    height: 20px;
+    width: 24px;
+    height: 24px;
     border-radius: 50%;
-    background: radial-gradient(circle at 30% 30%, #0a0503 0 6px, #1a0e06 7px);
+    background: radial-gradient(circle at 30% 30%, #0a0503 0 7px, #1a0e06 8px);
     border: 2px solid var(--brass-deep);
     box-shadow: inset 0 0 4px rgba(0, 0, 0, 1);
-    margin-bottom: 4px;
+    margin-bottom: 6px;
   }
   .plug .emoji {
-    font-size: 26px;
+    font-size: calc(var(--plug-size, 92px) * 0.38);
     line-height: 1;
-    margin-bottom: 2px;
+    margin-bottom: 4px;
   }
   .plug .name {
-    font-size: 10px;
+    font-size: 11px;
     letter-spacing: 0.05em;
     color: var(--cream);
     text-align: center;
-    line-height: 1.1;
+    line-height: 1.15;
     text-transform: uppercase;
   }
 
@@ -1300,6 +1336,32 @@
     padding-top: 6px;
     min-height: 12px;
   }
+  .slip-compare {
+    margin-top: 10px;
+    padding: 8px 10px;
+    background: rgba(40, 20, 0, 0.08);
+    border: 1px dashed #7a5a1e;
+    border-radius: 3px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .slip-compare-head {
+    font-size: 10px;
+    letter-spacing: 0.25em;
+    color: #7a5a1e;
+    text-align: center;
+    padding-bottom: 2px;
+    font-weight: bold;
+  }
+  .slip-row-mismatch {
+    background: rgba(255, 90, 78, 0.14);
+    border-bottom-color: #8a2a1e !important;
+    box-shadow: inset 0 0 0 1px rgba(138, 42, 30, 0.25);
+  }
+  .slip-row-mismatch b {
+    color: #8a2a1e;
+  }
   .slip-actions {
     display: flex;
     gap: 10px;
@@ -1503,6 +1565,90 @@
     opacity: 0.35;
     cursor: not-allowed;
   }
+  .agency-attend {
+    margin-top: 12px;
+    padding: 8px 10px;
+    background: rgba(255, 90, 78, 0.06);
+    border: 1px dashed #ff5a4e;
+    border-radius: 3px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .agency-attend-label {
+    font-size: 10px;
+    letter-spacing: 0.3em;
+    color: #ff8a80;
+    font-weight: bold;
+  }
+  .agency-attend-list {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .agency-attend-op {
+    display: grid;
+    grid-template-columns: 10px 1fr auto;
+    gap: 8px;
+    align-items: center;
+    padding: 3px 6px;
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    border-radius: 2px;
+    background: rgba(0, 0, 0, 0.25);
+    opacity: 0.55;
+  }
+  .agency-attend-op.on {
+    opacity: 1;
+    background: rgba(111, 224, 122, 0.1);
+  }
+  .agency-attend-op .dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    box-shadow: 0 0 6px currentColor;
+  }
+  .agency-attend-op .name {
+    color: #fff0ec;
+    font-weight: bold;
+  }
+  .agency-attend-op .state {
+    font-size: 9px;
+    letter-spacing: 0.2em;
+    color: #ff8a80;
+    text-transform: uppercase;
+  }
+  .agency-attend-op.on .state {
+    color: var(--green);
+  }
+  .agency-leave {
+    display: block;
+    margin: 10px auto 0;
+  }
+  .attend-row {
+    display: flex;
+    gap: 3px;
+    justify-content: center;
+    padding: 3px 0 2px;
+  }
+  .attend-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: transparent;
+    border: 1px solid var(--dotColor, #fff);
+    opacity: 0.35;
+    transition:
+      opacity 0.1s,
+      background 0.1s,
+      box-shadow 0.1s;
+  }
+  .attend-dot.on {
+    background: var(--dotColor, #fff);
+    opacity: 1;
+    box-shadow: 0 0 6px var(--dotColor, #fff);
+  }
   .agency-timer {
     margin-top: 14px;
     height: 6px;
@@ -1516,6 +1662,117 @@
     background: linear-gradient(90deg, #ff5a4e, #ffd561);
     width: 100%;
     transition: width 0.1s linear;
+  }
+
+  /* --------- Tutorial overlay --------- */
+  .help-fab {
+    position: fixed;
+    top: 10px;
+    right: 12px;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    border: 2px solid var(--brass-deep);
+    background: linear-gradient(180deg, var(--neon), var(--brass));
+    color: var(--ink);
+    font-family: inherit;
+    font-size: 16px;
+    font-weight: 900;
+    letter-spacing: 0;
+    cursor: pointer;
+    z-index: 250;
+    box-shadow:
+      0 3px 0 var(--brass-deep),
+      0 6px 14px rgba(0, 0, 0, 0.6);
+  }
+  .help-fab:hover {
+    filter: brightness(1.12);
+  }
+  .help-fab:active {
+    transform: translateY(2px);
+    box-shadow:
+      0 1px 0 var(--brass-deep),
+      0 2px 6px rgba(0, 0, 0, 0.6);
+  }
+
+  .tutorial-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.82);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 400;
+    animation: fade-in 0.15s ease-out;
+    padding: 20px;
+  }
+  .tutorial-card {
+    width: min(520px, 94vw);
+    background: linear-gradient(180deg, var(--wood-light), var(--wood));
+    border: 3px solid var(--brass-deep);
+    border-radius: 6px;
+    padding: 22px 26px;
+    color: var(--cream);
+    box-shadow:
+      0 20px 60px rgba(0, 0, 0, 0.85),
+      inset 0 0 40px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .tutorial-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-size: 10px;
+    letter-spacing: 0.3em;
+    color: var(--brass);
+    border-bottom: 1px dashed var(--brass-deep);
+    padding-bottom: 6px;
+  }
+  .tutorial-tag {
+    font-weight: bold;
+  }
+  .tutorial-progress {
+    color: var(--neon);
+  }
+  .tutorial-title {
+    font-size: 22px;
+    letter-spacing: 0.12em;
+    color: var(--neon);
+    text-shadow: 0 0 8px rgba(255, 213, 97, 0.35);
+    margin: 4px 0 0;
+  }
+  .tutorial-body {
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--cream);
+    opacity: 0.95;
+  }
+  .tutorial-dots {
+    display: flex;
+    gap: 5px;
+    justify-content: center;
+    margin-top: 4px;
+  }
+  .tutorial-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--wood);
+    border: 1px solid var(--brass-deep);
+  }
+  .tutorial-dot.active {
+    background: var(--neon);
+    box-shadow: 0 0 6px var(--neon);
+  }
+  .tutorial-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+    align-items: center;
+    margin-top: 4px;
+    flex-wrap: wrap;
   }
 
   /* --------- Responsive --------- */


### PR DESCRIPTION
Closes #49.

## Summary
- Added a 7-step skippable tutorial overlay (auto-shows once via `localStorage`, re-openable with a persistent `?` button or the `?` key).
- Expanded agency check-in questions with 7 new types on top of the original 5.
- Per-player answered indicator on tickets (colored dots per operator); dossier modal lists each operator as `ANSWERED` or `ringing...`.
- More call lines: new `CORRECT`/`WRONG` exchanges, bigger `WRONG_FALLBACK_A/B/C` banks, doubled `CLOSERS`, new `CORRECT_FALLBACK_*` banks.
- First-round rebalance: plug size scales with roster count; added a bottom `shift-briefing` panel with subtitle + control tips.
- Supervisor verification fix: tickets now show the true `t.to` (not the slip's claimed name), and the slip modal renders a side-by-side slip-vs-board compare with mismatch highlighting.

## Test plan
- [ ] Fresh profile sees tutorial; skip persists; re-open via button and `?` key.
- [ ] Call pool surfaces the new question types.
- [ ] Multi-client: confirm colored dots appear when other operators open the dossier.
- [ ] First round no longer has a large empty block at bottom of the switchboard.
- [ ] Supervisor role: slip with wrong caller/recipient highlights mismatches; patching after approval routes to the real `t.to`.