### PR TITLE
Signal Weave: add audio (#51)

### DIFF
--- a/src/lib/games/signal-weave/audio.ts
+++ b/src/lib/games/signal-weave/audio.ts
@@ -1,0 +1,180 @@
+import { blip as sharedBlip, getAudioContext } from "$lib/audio";
+
+// Procedural SFX for Signal Weave.  Mirrors the small-module pattern used by
+// `signal-grid/audio.ts` and `signal-cross/audio.ts`: shared WebAudio context,
+// tiny envelope-based tones, no binary assets, and a single mute toggle.
+export const Audio = (() => {
+  let ctx: AudioContext | null = null;
+  let muted = false;
+
+  function ensure(): AudioContext | null {
+    try {
+      if (!ctx) ctx = getAudioContext();
+      if (ctx.state === "suspended") void ctx.resume();
+      return ctx;
+    } catch {
+      return null;
+    }
+  }
+
+  function blip(freq = 660, dur = 0.06, type: OscillatorType = "square", vol = 0.05): void {
+    if (muted) return;
+    sharedBlip(freq, dur, type, vol);
+  }
+
+  function chord(freqs: number[], dur = 0.18, type: OscillatorType = "sine", vol = 0.05): void {
+    if (muted) return;
+    freqs.forEach((f, i) => setTimeout(() => blip(f, dur, type, vol), i * 70));
+  }
+
+  function noiseBurst(dur = 0.2, vol = 0.04, lpf = 1200): void {
+    if (muted) return;
+    const c = ensure();
+    if (!c) return;
+    try {
+      const buf = c.createBuffer(1, Math.max(1, Math.floor(c.sampleRate * dur)), c.sampleRate);
+      const data = buf.getChannelData(0);
+      for (let i = 0; i < data.length; i++) {
+        data[i] = (Math.random() * 2 - 1) * (1 - i / data.length);
+      }
+      const src = c.createBufferSource();
+      src.buffer = buf;
+      const filter = c.createBiquadFilter();
+      filter.type = "lowpass";
+      filter.frequency.setValueAtTime(lpf, c.currentTime);
+      const g = c.createGain();
+      g.gain.setValueAtTime(vol, c.currentTime);
+      g.gain.exponentialRampToValueAtTime(0.0001, c.currentTime + dur);
+      src.connect(filter);
+      filter.connect(g);
+      g.connect(c.destination);
+      src.start();
+    } catch {
+      // ignore
+    }
+  }
+
+  function sweep(
+    fromFreq: number,
+    toFreq: number,
+    dur = 0.25,
+    type: OscillatorType = "sine",
+    vol = 0.06
+  ): void {
+    if (muted) return;
+    const c = ensure();
+    if (!c) return;
+    try {
+      const o = c.createOscillator();
+      const g = c.createGain();
+      o.type = type;
+      o.frequency.setValueAtTime(fromFreq, c.currentTime);
+      o.frequency.exponentialRampToValueAtTime(Math.max(1, toFreq), c.currentTime + dur);
+      g.gain.setValueAtTime(0, c.currentTime);
+      g.gain.linearRampToValueAtTime(vol, c.currentTime + 0.01);
+      g.gain.exponentialRampToValueAtTime(0.0001, c.currentTime + dur);
+      o.connect(g);
+      g.connect(c.destination);
+      o.start();
+      o.stop(c.currentTime + dur + 0.02);
+    } catch {
+      // ignore
+    }
+  }
+
+  // ── Lobby / roster ─────────────────────────────────────────────────────────
+  function operatorJoin(): void {
+    // Rising two-note chirp
+    blip(520, 0.06, "triangle", 0.05);
+    setTimeout(() => blip(780, 0.08, "triangle", 0.05), 60);
+  }
+
+  function operatorLeave(): void {
+    // Falling two-note chirp
+    blip(520, 0.06, "triangle", 0.05);
+    setTimeout(() => blip(320, 0.1, "triangle", 0.05), 70);
+  }
+
+  // ── Pulses ─────────────────────────────────────────────────────────────────
+  // A short transmit blip when the local operator fires a pulse.  Frequency
+  // subtly varies with the phase offset so repeated pulses feel tactile.
+  function pulseSend(offsetRaw = 0): void {
+    const base = 520 + (offsetRaw % 120) * 1.2;
+    blip(base, 0.04, "triangle", 0.04);
+  }
+
+  // Tier-graded success tones. Bigger sync → more voices & more sparkle.
+  function pulsePair(): void {
+    // "spark" tier — two-note pair
+    chord([660, 880], 0.12, "sine", 0.05);
+  }
+
+  function pulseTeam(): void {
+    // "team" tier — three-note ascending arpeggio
+    chord([523, 784, 1046], 0.14, "sine", 0.06);
+  }
+
+  function pulseConstellation(): void {
+    // "constellation" tier — full major-7th arpeggio plus a shimmer sweep
+    chord([523, 659, 784, 1046, 1318], 0.18, "sine", 0.06);
+    setTimeout(() => sweep(1200, 2400, 0.35, "sine", 0.04), 120);
+  }
+
+  function pulseBad(): void {
+    // Out-of-phase buzz with a low thud
+    blip(180, 0.18, "sawtooth", 0.06);
+    noiseBurst(0.18, 0.03, 800);
+  }
+
+  // ── Round lifecycle ────────────────────────────────────────────────────────
+  function roundStart(): void {
+    // Three-note "carrier lock" fanfare
+    chord([440, 660, 990], 0.14, "square", 0.05);
+  }
+
+  function milestone(): void {
+    // Bright bell-like ping
+    blip(1320, 0.2, "sine", 0.06);
+    setTimeout(() => blip(1760, 0.18, "sine", 0.04), 80);
+  }
+
+  function modeChange(): void {
+    // Sweeping whoosh to signal the movement rotation
+    sweep(300, 900, 0.35, "triangle", 0.05);
+  }
+
+  function win(): void {
+    // Rising fanfare — four notes + sustained top
+    const notes = [523, 659, 784, 1047];
+    notes.forEach((f, i) => {
+      setTimeout(() => blip(f, i === notes.length - 1 ? 0.6 : 0.16, "sine", 0.07), i * 160);
+    });
+  }
+
+  function lose(): void {
+    // Descending stinger
+    const notes = [392, 349, 311, 261];
+    notes.forEach((f, i) => setTimeout(() => blip(f, 0.25, "sine", 0.06), i * 180));
+  }
+
+  return {
+    operatorJoin,
+    operatorLeave,
+    pulseSend,
+    pulsePair,
+    pulseTeam,
+    pulseConstellation,
+    pulseBad,
+    roundStart,
+    milestone,
+    modeChange,
+    win,
+    lose,
+    set muted(v: boolean) {
+      muted = v;
+    },
+    get muted() {
+      return muted;
+    },
+  };
+})();

--- a/src/lib/games/signal-weave/main.ts
+++ b/src/lib/games/signal-weave/main.ts
@@ -2,6 +2,7 @@ import Peer from "peerjs";
 import type { DataConnection } from "peerjs";
 import { createGameLoop } from "$lib/game-loop";
 import { describePeerError, makeCode } from "$lib/peer";
+import { Audio } from "./audio";
 
 // ── Tuning ─────────────────────────────────────────────────────────────────────
 
@@ -247,6 +248,7 @@ export function mount(
   function announceMilestone(text: string) {
     callbacks.onMilestone(text);
     log(text, "good");
+    Audio.milestone();
   }
 
   // ── Math ───────────────────────────────────────────────────────────────────
@@ -301,13 +303,18 @@ export function mount(
     // Mode announcements when target movement changes
     const m = modeAt(state.t);
     if (m !== lastModeAnnounced) {
+      const isFirstAnnouncement = lastModeAnnounced === null;
       lastModeAnnounced = m;
       callbacks.onMode(MODE_LABEL[m], MODE_PALETTE[m]);
       log(MODE_LABEL[m]);
+      // Don't whoosh on the very first announcement at round start — the
+      // roundStart fanfare covers that moment already.
+      if (!isFirstAnnouncement) Audio.modeChange();
     }
 
     if (state.timeLeft <= 0) {
       state.running = false;
+      const victorious = state.bestCombo >= 5 || state.harmony > 200;
       const top =
         state.bestCombo >= 8
           ? "Constellation forged."
@@ -319,6 +326,8 @@ export function mount(
       broadcast({ t: "end", harmony: state.harmony.toFixed(1), topMessage: top });
       log(`Weave complete. Harmony ${state.harmony.toFixed(1)} • Best combo ${state.bestCombo}.`);
       announceMilestone(top);
+      if (victorious) Audio.win();
+      else Audio.lose();
     }
   }
 
@@ -378,6 +387,7 @@ export function mount(
       state.pulses.push({ owner: slot, t: now, good: true });
       broadcast({ t: "burst", good: true, tier, sync: synced });
       callbacks.onFlash(tier === "constellation" ? "perfect" : "good");
+      playBurstSfx(true, tier);
       const msg =
         tier === "constellation"
           ? `Full constellation (${synced}/${state.players}) — +${baseGain + comboBonus} harmony.`
@@ -390,8 +400,19 @@ export function mount(
       state.harmony = Math.max(0, state.harmony - 6);
       broadcast({ t: "burst", good: false, tier: "spark", sync: synced });
       callbacks.onFlash("bad");
+      playBurstSfx(false, "spark");
       log(`Pulse out of phase (${synced} synced).`, "bad");
     }
+  }
+
+  function playBurstSfx(good: boolean, tier: BurstTier) {
+    if (!good) {
+      Audio.pulseBad();
+      return;
+    }
+    if (tier === "constellation") Audio.pulseConstellation();
+    else if (tier === "team") Audio.pulseTeam();
+    else Audio.pulsePair();
   }
 
   function startRound() {
@@ -409,6 +430,7 @@ export function mount(
     broadcast({ t: "start" });
     callbacks.onGameStart();
     log("Carrier locked. Weave active.");
+    Audio.roundStart();
   }
 
   function resetNet() {
@@ -442,6 +464,7 @@ export function mount(
       );
       log(`Operator ${slot + 1} tuned in.`, "good");
       pushRoster();
+      Audio.operatorJoin();
     });
     c.on("data", (d: unknown) => {
       if (isHostMsg(d)) onHostMessage(d, slot);
@@ -459,6 +482,7 @@ export function mount(
       callbacks.onLobbyStatus(`Operator ${slot + 1} disconnected.`);
       log(`Operator ${slot + 1} dropped.`, "bad");
       pushRoster();
+      Audio.operatorLeave();
     });
   }
 
@@ -535,6 +559,8 @@ export function mount(
     }
   }
 
+  let lastGuestMode: TargetMode | null = null;
+
   function onGuestMessage(d: GuestMsg) {
     if (d.t === "hello") {
       mySlot = d.slot;
@@ -543,18 +569,28 @@ export function mount(
       callbacks.onLobbyStatus("Linked as operator " + (mySlot + 1) + ".");
       pushRoster();
     } else if (d.t === "roster") {
+      const before = state.players;
       state.players = d.players;
       pushRoster();
+      if (d.players > before) Audio.operatorJoin();
+      else if (d.players < before) Audio.operatorLeave();
     } else if (d.t === "start") {
       callbacks.onGameStart();
       log("Host started the weave.");
+      Audio.roundStart();
+      lastGuestMode = null;
     } else if (d.t === "state") {
       localSnapshot = d.s;
       // mirror what the host knows so we draw consistently
       state.players = d.s.players;
       callbacks.onMode(MODE_LABEL[d.s.mode], MODE_PALETTE[d.s.mode]);
+      if (lastGuestMode !== null && d.s.mode !== lastGuestMode) {
+        Audio.modeChange();
+      }
+      lastGuestMode = d.s.mode;
     } else if (d.t === "burst") {
       callbacks.onFlash(d.good ? (d.tier === "constellation" ? "perfect" : "good") : "bad");
+      playBurstSfx(d.good, d.tier);
       log(
         d.good ? `Burst (${d.sync} synced).` : `Pulse out of phase (${d.sync} synced).`,
         d.good ? "good" : "bad"
@@ -562,6 +598,9 @@ export function mount(
     } else if (d.t === "end") {
       log(`Weave complete. Harmony ${d.harmony}.`, "good");
       callbacks.onMilestone(d.topMessage);
+      const harmonyNum = parseFloat(d.harmony);
+      if (!Number.isNaN(harmonyNum) && harmonyNum > 200) Audio.win();
+      else Audio.lose();
     } else if (d.t === "reject") {
       callbacks.onLobbyStatus(d.reason ?? "Unable to join room.");
     }
@@ -581,6 +620,7 @@ export function mount(
   }
 
   function doPulse() {
+    Audio.pulseSend(currentOffsetRaw);
     if (isHost) onPing(0);
     else if (conn && conn.open) conn.send({ t: "ping" });
   }


### PR DESCRIPTION
Closes #51.

## Summary
Added a per-game procedural audio module (`src/lib/games/signal-weave/audio.ts`) matching the pattern used by `signal-grid/audio.ts` and `signal-cross/audio.ts`. No binary assets; shared WebAudio context with a mute toggle.

Sounds wired into key moments:
- Operator join/leave (rising/falling triangle chirps)
- Local pulse send (triangle blip tinted by phase offset)
- Pair pulse / team burst / constellation successes (tier-aware arpeggios + shimmer)
- Bad / out-of-phase pulse (sawtooth buzz + noise burst)
- Round start (3-note "carrier lock")
- Milestone (bell ping)
- Mode change (300→900 Hz whoosh, guarded against initial announcement)
- Win / lose (fanfare / descending stinger)

## Test plan
- [ ] Start a solo weave session; confirm round-start, pulse, and milestone SFX fire at expected moments.
- [ ] Invite an operator; confirm join/leave chirps on both sides.
- [ ] Trigger a constellation (all synced) and a bad pulse; confirm distinct audio.
- [ ] Let a round end in both win and lose conditions; confirm correct end sting.