### PR TITLE
Signal Surge follow-up fixes (#53)

### DIFF
--- a/src/lib/games/signal-surge/Scene.svelte
+++ b/src/lib/games/signal-surge/Scene.svelte
@@ -7,6 +7,7 @@
   import {
     LANE_COUNT,
     LANE_WIDTH,
+    LASER_SHOW_DURATION,
     centerlineSlope,
     centerlineX,
     getTrackVariant,
@@ -35,6 +36,10 @@
   let lookY = 0.8;
   let lookZ = 6;
   let cameraRef = $state<THREE.PerspectiveCamera>(new THREE.PerspectiveCamera());
+  // Lingering boost "kick" — drives brief screen shake when boost/burst begins.
+  // These are local tick state, not reactive.
+  let boostShake = 0;
+  let prevBoosted = false;
 
   interface Smoothed {
     z: number;
@@ -124,6 +129,14 @@
       smoothed.clear();
     }
 
+    // Screen-shake decay; triggers on boost/burst rising edge.
+    const me = renderedPlayers.find((p) => p.slot === gs.mySlot);
+    const nowT = snap?.t ?? 0;
+    const meBoosted = me ? nowT < me.boostUntil || nowT < me.burstUntil : false;
+    if (meBoosted && !prevBoosted) boostShake = 1;
+    prevBoosted = meBoosted;
+    boostShake = Math.max(0, boostShake - dt * 4);
+
     // Camera: follow curve tangent for a proper chase cam on bends.
     let targetCamX: number;
     let targetCamY: number;
@@ -131,13 +144,14 @@
     let targetLookX: number;
     let targetLookY: number;
     let targetLookZ: number;
-    const me = renderedPlayers.find((p) => p.slot === gs.mySlot);
     if (me) {
       const behind = worldPosForLane(me.renderZ - 7.5, me.renderLaneX, variant);
       const ahead = worldPosForLane(me.renderZ + 6, me.renderLaneX, variant);
+      // Pull camera slightly back & higher during boost for FOV-ish feel.
+      const boostPush = meBoosted ? 1.3 : 0;
       targetCamX = behind.x;
-      targetCamY = 5.2;
-      targetCamZ = behind.z;
+      targetCamY = 5.2 + (meBoosted ? 0.2 : 0);
+      targetCamZ = behind.z - boostPush;
       targetLookX = ahead.x;
       targetLookY = 0.8;
       targetLookZ = ahead.z;
@@ -161,7 +175,11 @@
     lookZ += (targetLookZ - lookZ) * easeLook;
 
     if (cameraRef) {
-      cameraRef.position.set(camX, camY, camZ);
+      // Apply short-lived shake on top of eased cam.
+      const shakeAmp = boostShake * 0.18;
+      const shakeX = Math.sin(pulseT * 80) * shakeAmp;
+      const shakeY = Math.cos(pulseT * 73) * shakeAmp;
+      cameraRef.position.set(camX + shakeX, camY + shakeY, camZ);
       cameraRef.lookAt(lookX, lookY, lookZ);
     }
   });
@@ -310,13 +328,87 @@
     return out;
   }
 
+  interface SkylineItem {
+    id: number;
+    x: number;
+    z: number;
+    height: number;
+    width: number;
+  }
+  function buildSkyline(v: TrackVariant): SkylineItem[] {
+    // Distant silhouette elements so each theme reads distinctly in the background.
+    const out: SkylineItem[] = [];
+    const rng = (() => {
+      let s = 0x9e3779b1;
+      // Mix in the variant id for stable per-theme skyline layout.
+      for (let i = 0; i < v.id.length; i += 1) s = Math.imul(s ^ v.id.charCodeAt(i), 0x85ebca6b);
+      return () => {
+        s = Math.imul(s ^ (s >>> 13), 0xc2b2ae35);
+        s = (s + 0x165667b1) | 0;
+        return ((s >>> 0) % 10000) / 10000;
+      };
+    })();
+    const offsetBase = TRACK_HALF_WIDTH + 14;
+    let id = 0;
+    for (let z = -20; z < v.trackLength + 20; z += 6 + rng() * 4) {
+      for (const side of [-1, 1]) {
+        const jitter = rng() * 6;
+        const pos = worldPosForLane(z, side * (offsetBase + jitter), v);
+        out.push({
+          id: id++,
+          x: pos.x,
+          z: pos.z,
+          height: 4 + rng() * 18,
+          width: 1.4 + rng() * 2.2,
+        });
+      }
+    }
+    return out;
+  }
+
   const trackGeos = $derived(getTrackGeos(activeVariant));
   const railSegments = $derived(buildRailSegments(activeVariant));
   const markerSegments = $derived(buildMarkers(activeVariant));
   const trackProps = $derived(buildProps(activeVariant));
   const trackArches = $derived(buildArches(activeVariant));
+  const skyline = $derived(buildSkyline(activeVariant));
   const startPos = $derived(worldPosForLane(0, 0, activeVariant));
   const finishPos = $derived(worldPosForLane(activeVariant.trackLength, 0, activeVariant));
+
+  interface RenderedBeam {
+    key: string;
+    slot: number;
+    fromZ: number;
+    toZ: number;
+    lane: number;
+    firedAt: number;
+    alpha: number;
+  }
+  const renderedBeams = $derived.by(() => {
+    const snap = gs.snapshot;
+    if (!snap) return [] as RenderedBeam[];
+    return snap.beams
+      .map((b, idx) => {
+        const age = snap.t - b.firedAt;
+        const alpha = Math.max(0, 1 - age / LASER_SHOW_DURATION);
+        return {
+          key: `${b.slot}-${b.firedAt}-${idx}`,
+          slot: b.slot,
+          fromZ: b.fromZ,
+          toZ: b.toZ,
+          lane: b.lane,
+          firedAt: b.firedAt,
+          alpha,
+        };
+      })
+      .filter((b) => b.alpha > 0.01);
+  });
+
+  function colorForSlot(slot: number): number {
+    const snap = gs.snapshot;
+    const p = snap?.players.find((q) => q.slot === slot);
+    return p ? colorToHex(p.color) : 0xffffff;
+  }
 </script>
 
 <T.PerspectiveCamera bind:ref={cameraRef} makeDefault fov={62} near={0.1} far={500} />
@@ -337,6 +429,46 @@
   shadow.camera.bottom={-30}
 />
 <T.HemisphereLight args={[0x3344aa, 0x050510, 0.4]} />
+
+<!-- Theme-specific ambient accent (tints the scene subtly per variant) -->
+<T.PointLight
+  color={activeVariant.glowColor}
+  intensity={0.6}
+  distance={180}
+  decay={1.6}
+  position={[0, 30, activeVariant.trackLength / 2]}
+/>
+
+<!-- Distant skyline silhouettes — a simple backdrop that differs per theme -->
+{#each skyline as s (s.id)}
+  <T.Mesh position={[s.x, s.height / 2, s.z]}>
+    <T.BoxGeometry args={[s.width, s.height, s.width]} />
+    {#if activeVariant.theme === "solar-flare" || activeVariant.theme === "volcanic"}
+      <T.MeshStandardMaterial
+        color={activeVariant.accentColor}
+        emissive={activeVariant.glowColor}
+        emissiveIntensity={0.25}
+        roughness={0.9}
+      />
+    {:else if activeVariant.theme === "emerald-grid"}
+      <T.MeshBasicMaterial color={activeVariant.accentColor} transparent opacity={0.8} />
+    {:else if activeVariant.theme === "deep-ocean"}
+      <T.MeshStandardMaterial
+        color={activeVariant.accentColor}
+        emissive={activeVariant.glowColor}
+        emissiveIntensity={0.18}
+        roughness={0.85}
+      />
+    {:else}
+      <T.MeshStandardMaterial
+        color={activeVariant.accentColor}
+        emissive={activeVariant.railColor}
+        emissiveIntensity={0.12}
+        roughness={0.75}
+      />
+    {/if}
+  </T.Mesh>
+{/each}
 
 <!-- Continuous curved track surface -->
 <T.Mesh receiveShadow geometry={trackGeos.track}>
@@ -469,6 +601,34 @@
         <T.CylinderGeometry args={[0.05, 0.07, 1.6, 8]} />
         <T.MeshStandardMaterial color={activeVariant.accentColor} roughness={0.6} />
       </T.Mesh>
+    {:else if activeVariant.propStyle === "monolith"}
+      <T.Mesh position={[0, 1.8, 0]}>
+        <T.BoxGeometry args={[0.6, 3.6, 0.35]} />
+        <T.MeshStandardMaterial
+          color={activeVariant.accentColor}
+          emissive={activeVariant.propColor}
+          emissiveIntensity={0.28 + Math.abs(Math.sin(pulseT * 1.3 + prop.id * 0.4)) * 0.25}
+          roughness={0.4}
+        />
+      </T.Mesh>
+      <T.Mesh position={[0, 0.15, 0]}>
+        <T.BoxGeometry args={[0.9, 0.12, 0.6]} />
+        <T.MeshStandardMaterial color={activeVariant.accentColor} roughness={0.6} />
+      </T.Mesh>
+    {:else if activeVariant.propStyle === "spire"}
+      <T.Mesh position={[0, 1.8, 0]} rotation.z={Math.sin(prop.id * 0.3) * 0.08}>
+        <T.ConeGeometry args={[0.18, 3.6, 6]} />
+        <T.MeshStandardMaterial
+          color={activeVariant.propColor}
+          emissive={activeVariant.propColor}
+          emissiveIntensity={0.7 + Math.sin(pulseT * 2 + prop.id) * 0.35}
+          roughness={0.35}
+        />
+      </T.Mesh>
+      <T.Mesh position={[0, 0.25, 0]}>
+        <T.ConeGeometry args={[0.55, 0.5, 6]} />
+        <T.MeshStandardMaterial color={activeVariant.accentColor} roughness={0.7} />
+      </T.Mesh>
     {:else}
       <T.Mesh position={[0, 2.2, 0]}>
         <T.BoxGeometry args={[0.45, 4.4, 0.45]} />
@@ -529,7 +689,7 @@
 
 {#if currentSnapshot}
   {@const snap = currentSnapshot}
-  <!-- Obstacles -->
+  <!-- Obstacles (only alive ones are sent over the wire) -->
   {#each snap.obstacles as obs (obs.id)}
     {@const ox = laneToX(obs.lane)}
     {@const wp = worldPosForLane(obs.z, ox, activeVariant)}
@@ -580,10 +740,46 @@
     {/if}
   {/each}
 
+  <!-- Laser beams -->
+  {#each renderedBeams as beam (beam.key)}
+    {@const laneX = laneToX(beam.lane)}
+    {@const mid = (beam.fromZ + beam.toZ) / 2}
+    {@const midPos = worldPosForLane(mid, laneX, activeVariant)}
+    {@const beamColor = colorForSlot(beam.slot)}
+    {@const beamLength = Math.max(0.1, beam.toZ - beam.fromZ)}
+    <T.Group position={[midPos.x, 0.85, midPos.z]} rotation.y={midPos.angleY}>
+      <T.Mesh>
+        <T.BoxGeometry args={[0.18, 0.18, beamLength]} />
+        <T.MeshBasicMaterial
+          color={beamColor}
+          transparent
+          opacity={0.85 * beam.alpha}
+          depthWrite={false}
+        />
+      </T.Mesh>
+      <T.Mesh>
+        <T.BoxGeometry args={[0.55, 0.55, beamLength]} />
+        <T.MeshBasicMaterial
+          color={beamColor}
+          transparent
+          opacity={0.25 * beam.alpha}
+          depthWrite={false}
+        />
+      </T.Mesh>
+      <T.PointLight
+        color={beamColor}
+        intensity={2.4 * beam.alpha}
+        distance={Math.min(18, beamLength * 0.8)}
+        decay={2}
+      />
+    </T.Group>
+  {/each}
+
   <!-- Players -->
   {#each renderedPlayers as player (player.slot)}
     {@const color = colorToHex(player.color)}
     {@const boosted = snap.t < player.boostUntil || snap.t < player.burstUntil}
+    {@const bursting = snap.t < player.burstUntil}
     {@const slowed = snap.t < player.slowUntil}
     {@const hover = 0.75 + Math.sin(pulseT * 6 + player.slot) * 0.08}
     <T.Group position={[player.worldX, hover, player.worldZ]} rotation.y={player.angleY}>
@@ -592,7 +788,7 @@
         <T.MeshStandardMaterial
           {color}
           emissive={color}
-          emissiveIntensity={boosted ? 1.4 : 0.55}
+          emissiveIntensity={boosted ? 1.8 + Math.sin(pulseT * 18 + player.slot) * 0.4 : 0.55}
           roughness={0.25}
           metalness={0.3}
         />
@@ -602,16 +798,38 @@
         <T.MeshStandardMaterial
           {color}
           emissive={color}
-          emissiveIntensity={boosted ? 1.9 : 0.9}
+          emissiveIntensity={boosted ? 2.2 : 0.9}
           transparent
           opacity={0.8}
         />
       </T.Mesh>
       {#if boosted}
+        <!-- Big glowing exhaust cone during boost -->
         <T.Mesh position={[0, 0, -1.2]} rotation.x={Math.PI / 2}>
-          <T.ConeGeometry args={[0.24, 1.3, 12]} />
-          <T.MeshBasicMaterial {color} transparent opacity={0.55} depthWrite={false} />
+          <T.ConeGeometry args={[bursting ? 0.32 : 0.24, bursting ? 1.9 : 1.3, 12]} />
+          <T.MeshBasicMaterial {color} transparent opacity={0.65} depthWrite={false} />
         </T.Mesh>
+        <!-- Particle trail: evenly spaced puffs behind the craft -->
+        {#each [1, 2, 3, 4, 5] as i (i)}
+          {@const fade = 1 - i / 6}
+          {@const wob = Math.sin(pulseT * 14 + player.slot + i) * 0.08}
+          <T.Mesh position={[wob, -0.1 - wob * 0.4, -1.2 - i * 0.55]}>
+            <T.SphereGeometry args={[0.15 + fade * 0.15, 8, 8]} />
+            <T.MeshBasicMaterial
+              {color}
+              transparent
+              opacity={fade * (bursting ? 0.75 : 0.55)}
+              depthWrite={false}
+            />
+          </T.Mesh>
+        {/each}
+        <!-- Streaks / speed lines -->
+        {#each [-1, 1] as s (s)}
+          <T.Mesh position={[s * 0.45, 0, -0.9]} rotation.x={Math.PI / 2}>
+            <T.BoxGeometry args={[0.04, 0.04, bursting ? 2.6 : 1.8]} />
+            <T.MeshBasicMaterial {color} transparent opacity={0.75} depthWrite={false} />
+          </T.Mesh>
+        {/each}
       {/if}
       {#if slowed}
         <T.Mesh position={[0, 0, 0]}>
@@ -625,7 +843,7 @@
           <T.MeshBasicMaterial {color} transparent opacity={0.8} depthWrite={false} />
         </T.Mesh>
       {/if}
-      <T.PointLight {color} intensity={boosted ? 2.6 : 1.3} distance={7} decay={2} />
+      <T.PointLight {color} intensity={boosted ? 3.6 : 1.3} distance={boosted ? 10 : 7} decay={2} />
     </T.Group>
   {/each}
 {/if}

--- a/src/lib/games/signal-surge/gameState.svelte.ts
+++ b/src/lib/games/signal-surge/gameState.svelte.ts
@@ -23,6 +23,7 @@ type GameStateType = {
   pendingLane: number;
   hudProgress: string;
   hudBursts: number;
+  hudLaser: number;
   hudPlace: string;
   hudTotal: number;
   selectedTrackId: string;
@@ -55,6 +56,7 @@ export const gs: GameStateType = $state({
   pendingLane: 2,
   hudProgress: "0.0",
   hudBursts: 0,
+  hudLaser: 0,
   hudPlace: "-",
   hudTotal: 0,
   selectedTrackId: DEFAULT_TRACK_ID,
@@ -93,6 +95,7 @@ export function resetState(): void {
   gs.pendingLane = 2;
   gs.hudProgress = "0.0";
   gs.hudBursts = 0;
+  gs.hudLaser = 0;
   gs.hudPlace = "-";
   gs.hudTotal = 0;
   gs.activeTrackId = DEFAULT_TRACK_ID;

--- a/src/lib/games/signal-surge/main.ts
+++ b/src/lib/games/signal-surge/main.ts
@@ -6,6 +6,7 @@ import { describePeerError, makeCode } from "$lib/peer";
 import { gs, pushLog, resetState } from "./gameState.svelte.js";
 import type {
   GameSnapshot,
+  LaserBeam,
   Obstacle,
   ObstacleKind,
   PlayerSnap,
@@ -21,12 +22,18 @@ import {
   LANE_COUNT,
   BASE_SPEED,
   NOISE_SLOW,
-  NOISE_DURATION,
   AMP_BOOST_SPEED,
   AMP_DURATION,
   BURST_SPEED,
   BURST_DURATION,
   BURST_CHARGES,
+  LASER_COOLDOWN_BASE,
+  LASER_COOLDOWN_TAIL,
+  LASER_RANGE,
+  LASER_SLOW_DURATION,
+  LASER_SHOW_DURATION,
+  WALL_BUST_PENALTY_DURATION,
+  WALL_BUST_PENALTY_SPEED,
   NETWORK_TICK_RATE,
   ROOM_CODE_LENGTH,
   COUNTDOWN_SECONDS,
@@ -44,6 +51,7 @@ interface IntentMsg {
   t: "intent";
   lane?: number;
   burst?: boolean;
+  laser?: boolean;
 }
 interface HelloJoinMsg {
   t: "helloJoin";
@@ -108,9 +116,12 @@ interface HostPlayer {
   boostUntil: number;
   burstUntil: number;
   burstsLeft: number;
+  /** Penalty after smashing through a wall; a short-lived partial slow. */
+  wallBustUntil: number;
+  /** Current laser charge 0..1, 1 == ready to fire. */
+  laserCharge: number;
   finished: boolean;
   finishTime: number | null;
-  consumed: Set<number>;
 }
 
 function createRng(seed: number): () => number {
@@ -134,7 +145,7 @@ function buildObstacles(seed: number, variant: TrackVariant): Obstacle[] {
     }
     for (const lane of lanes) {
       const kind: ObstacleKind = rng() < variant.ampRatio ? "amp" : "noise";
-      obstacles.push({ id: id++, kind, lane, z: z + (rng() - 0.5) * 1.4 });
+      obstacles.push({ id: id++, kind, lane, z: z + (rng() - 0.5) * 1.4, alive: true });
     }
   }
   return obstacles;
@@ -156,6 +167,7 @@ let hostWinnerSlot: number | null = null;
 let hostFinishOrder: number[] = [];
 let hostGraceTimer = 0;
 let hostObstacles: Obstacle[] = [];
+let hostBeams: LaserBeam[] = [];
 let hostTrackVariant: TrackVariant = getTrackVariant(null);
 const hostCupStandings = new Map<number, CupStanding>();
 let hostCupOrder: TrackVariant[] = [];
@@ -202,16 +214,24 @@ function buildSnapshot(): GameSnapshot {
       boostUntil: p.boostUntil,
       burstUntil: p.burstUntil,
       burstsLeft: p.burstsLeft,
+      laserCharge: p.laserCharge,
       finished: p.finished,
       finishTime: p.finishTime,
     }));
+  // Only broadcast still-alive obstacles; clients should not render destroyed walls.
+  // Amps stay alive once consumed too, but we purge consumed amps via their absence is
+  // not an issue: amps are single-use but we keep them in the world so everyone sees
+  // them. Walls become !alive when destroyed. Skip dead walls here.
+  const liveObstacles = hostObstacles.filter((o) => o.alive);
+  const visibleBeams = hostBeams.filter((b) => hostTime - b.firedAt <= LASER_SHOW_DURATION);
   return {
     t: hostTime,
     running: hostRunning,
     finished: hostFinished,
     countdown: hostCountdown,
     players,
-    obstacles: hostObstacles,
+    obstacles: liveObstacles,
+    beams: visibleBeams,
     trackLength: hostTrackVariant.trackLength,
     laneCount: LANE_COUNT,
     trackId: hostTrackVariant.id,
@@ -232,6 +252,7 @@ function publishSnapshot(s: GameSnapshot): void {
   if (me) {
     gs.hudProgress = ((me.z / s.trackLength) * 100).toFixed(1);
     gs.hudBursts = me.burstsLeft;
+    gs.hudLaser = Math.max(0, Math.min(1, me.laserCharge));
     const sorted = [...s.players].sort((a, b) => b.z - a.z);
     const place = sorted.findIndex((p) => p.slot === gs.mySlot) + 1;
     gs.hudPlace = String(place);
@@ -257,7 +278,71 @@ function speedFor(p: HostPlayer): number {
   if (hostTime < p.boostUntil) return AMP_BOOST_SPEED;
   let speed = BASE_SPEED;
   if (hostTime < p.slowUntil) speed *= NOISE_SLOW;
+  if (hostTime < p.wallBustUntil) speed *= WALL_BUST_PENALTY_SPEED;
   return speed;
+}
+
+/**
+ * Laser recharge rate scales with trailing position: last place recharges fastest
+ * (catch-up), leader slowest. Returns units of charge per second.
+ */
+function laserRechargeRate(p: HostPlayer): number {
+  if (p.finished) return 0;
+  const players = [...hostPlayers.values()];
+  if (players.length <= 1) return 1 / LASER_COOLDOWN_BASE;
+  const sorted = [...players].sort((a, b) => b.z - a.z);
+  const placeIdx = sorted.findIndex((q) => q.slot === p.slot); // 0 = leader
+  const frac = placeIdx / Math.max(1, sorted.length - 1); // 0 leader .. 1 last
+  const cooldown = LASER_COOLDOWN_BASE + (LASER_COOLDOWN_TAIL - LASER_COOLDOWN_BASE) * frac;
+  return 1 / cooldown;
+}
+
+function fireLaser(p: HostPlayer): boolean {
+  if (p.finished) return false;
+  if (p.laserCharge < 1) return false;
+  if (hostTime < (hostCountdown > 0 ? Infinity : 0)) return false;
+  // Find the nearest target in the same lane and ahead, within range.
+  let beamToZ = p.z + LASER_RANGE;
+  // Walls along the beam path: destroy every alive wall in the lane up to first player hit.
+  let firstPlayerHitZ = Infinity;
+  for (const other of hostPlayers.values()) {
+    if (other.slot === p.slot) continue;
+    if (other.finished) continue;
+    if (other.lane !== p.lane) continue;
+    if (other.z <= p.z) continue;
+    if (other.z - p.z > LASER_RANGE) continue;
+    if (other.z < firstPlayerHitZ) firstPlayerHitZ = other.z;
+  }
+  const cutoff = Math.min(beamToZ, firstPlayerHitZ);
+  // Destroy alive walls before the cutoff point (amps are unaffected).
+  for (const obs of hostObstacles) {
+    if (!obs.alive) continue;
+    if (obs.kind !== "noise") continue;
+    if (obs.lane !== p.lane) continue;
+    if (obs.z <= p.z) continue;
+    if (obs.z > cutoff) continue;
+    obs.alive = false;
+  }
+  // Apply slow to the first player in the beam's path.
+  if (firstPlayerHitZ !== Infinity) {
+    for (const other of hostPlayers.values()) {
+      if (other.lane === p.lane && other.z === firstPlayerHitZ && !other.finished) {
+        other.slowUntil = Math.max(other.slowUntil, hostTime + LASER_SLOW_DURATION);
+        pushLog(`${p.name} lased ${other.name}.`, "good");
+        break;
+      }
+    }
+    beamToZ = firstPlayerHitZ;
+  }
+  p.laserCharge = 0;
+  hostBeams.push({
+    slot: p.slot,
+    fromZ: p.z,
+    toZ: beamToZ,
+    lane: p.lane,
+    firedAt: hostTime,
+  });
+  return true;
 }
 
 function hostTick(dt: number): void {
@@ -268,6 +353,11 @@ function hostTick(dt: number): void {
     return;
   }
 
+  // Prune expired beams (anything older than the show duration).
+  if (hostBeams.length > 0) {
+    hostBeams = hostBeams.filter((b) => hostTime - b.firedAt <= LASER_SHOW_DURATION);
+  }
+
   for (const p of hostPlayers.values()) {
     if (p.finished) continue;
     if (p.lane !== p.targetLane) p.lane = clampLane(p.lane + Math.sign(p.targetLane - p.lane));
@@ -275,15 +365,23 @@ function hostTick(dt: number): void {
     p.z = Math.min(hostTrackVariant.trackLength, p.z + speedFor(p) * dt);
 
     for (const obs of hostObstacles) {
-      if (p.consumed.has(obs.id)) continue;
+      if (!obs.alive) continue;
       if (obs.lane !== p.lane) continue;
       if (obs.z < prevZ - 0.4 || obs.z > p.z + 0.4) continue;
-      p.consumed.add(obs.id);
       if (obs.kind === "amp") {
+        // Amps are first-come-first-served; once picked up they're gone for everyone.
+        obs.alive = false;
         p.boostUntil = Math.max(p.boostUntil, hostTime + AMP_DURATION);
       } else {
-        p.slowUntil = Math.max(p.slowUntil, hostTime + NOISE_DURATION);
+        // Wall: player smashes through, wall destroyed globally, speed penalty applied.
+        obs.alive = false;
+        p.wallBustUntil = Math.max(p.wallBustUntil, hostTime + WALL_BUST_PENALTY_DURATION);
       }
+    }
+
+    // Laser recharge.
+    if (p.laserCharge < 1) {
+      p.laserCharge = Math.min(1, p.laserCharge + laserRechargeRate(p) * dt);
     }
 
     if (!p.finished && p.z >= hostTrackVariant.trackLength) {
@@ -419,6 +517,7 @@ function resetRoundState(variant: TrackVariant): void {
   gs.activeTrackId = hostTrackVariant.id;
   const seed = (Math.random() * 0xffffffff) >>> 0;
   hostObstacles = buildObstacles(seed, hostTrackVariant);
+  hostBeams = [];
   hostTime = 0;
   hostCountdown = COUNTDOWN_SECONDS;
   hostRunning = true;
@@ -439,9 +538,10 @@ function resetRoundState(variant: TrackVariant): void {
     p.boostUntil = 0;
     p.burstUntil = 0;
     p.burstsLeft = BURST_CHARGES;
+    p.wallBustUntil = 0;
+    p.laserCharge = 0;
     p.finished = false;
     p.finishTime = null;
-    p.consumed = new Set();
   });
 }
 
@@ -503,9 +603,10 @@ function handleHostMessage(msg: HostMsg, fromId: string): void {
       boostUntil: 0,
       burstUntil: 0,
       burstsLeft: BURST_CHARGES,
+      wallBustUntil: 0,
+      laserCharge: 0,
       finished: false,
       finishTime: null,
-      consumed: new Set(),
     });
     if (c && c.open) c.send({ t: "hello", slot });
     gs.lobbyPlayers = lobbyPlayersList();
@@ -520,6 +621,9 @@ function handleHostMessage(msg: HostMsg, fromId: string): void {
     if (msg.burst && p.burstsLeft > 0 && hostTime >= p.burstUntil) {
       p.burstsLeft -= 1;
       p.burstUntil = hostTime + BURST_DURATION;
+    }
+    if (msg.laser && hostCountdown <= 0 && hostRunning) {
+      fireLaser(p);
     }
   }
 }
@@ -588,6 +692,7 @@ function resetNet(): void {
   isHost = false;
   myId = null;
   hostObstacles = [];
+  hostBeams = [];
   hostTrackVariant = getTrackVariant(null);
   hostCupStandings.clear();
   hostCupOrder = [];
@@ -634,9 +739,10 @@ export function hostGame(name: string): void {
       boostUntil: 0,
       burstUntil: 0,
       burstsLeft: BURST_CHARGES,
+      wallBustUntil: 0,
+      laserCharge: 0,
       finished: false,
       finishTime: null,
-      consumed: new Set(),
     });
     gs.slotLabel = "P1";
     gs.pendingLane = Math.floor(LANE_COUNT / 2);
@@ -702,17 +808,27 @@ function triggerBurst(): void {
   sendToHost({ t: "intent", burst: true });
 }
 
+function triggerLaser(): void {
+  sendToHost({ t: "intent", laser: true });
+}
+
 function handleKeyDown(e: KeyboardEvent): void {
   if (!gs.snapshot?.running) return;
   if (e.code === "ArrowLeft" || e.code === "KeyA") {
     e.preventDefault();
-    setLane(gs.pendingLane - 1);
+    // Chase camera looks from -Z toward +Z, which flips world X on screen:
+    // world +X appears on screen LEFT, world -X on screen RIGHT. Lanes increase with +X.
+    // So "screen left" must correspond to increasing lane index.
+    setLane(gs.pendingLane + 1);
   } else if (e.code === "ArrowRight" || e.code === "KeyD") {
     e.preventDefault();
-    setLane(gs.pendingLane + 1);
+    setLane(gs.pendingLane - 1);
   } else if (e.code === "Space") {
     e.preventDefault();
     triggerBurst();
+  } else if (e.code === "KeyF" || e.code === "ShiftLeft" || e.code === "ShiftRight") {
+    e.preventDefault();
+    triggerLaser();
   }
 }
 

--- a/src/lib/games/signal-surge/types.ts
+++ b/src/lib/games/signal-surge/types.ts
@@ -14,6 +14,18 @@ export const BURST_SPEED = 34;
 export const BURST_DURATION = 1.2;
 export const BURST_CHARGES = 3;
 
+// Laser (catch-up mechanic): slows hit opponents, obliterates walls in its path.
+export const LASER_COOLDOWN_BASE = 9; // seconds to fully recharge from empty when leading
+export const LASER_COOLDOWN_TAIL = 4; // seconds to fully recharge from empty when last
+export const LASER_RANGE = 60;
+export const LASER_SLOW_DURATION = 1.4;
+export const LASER_SHOW_DURATION = 0.35; // how long the beam is drawn after firing
+export const LASER_WALL_PENALTY = 0.15; // wall hit cost to laser beam carrier speed (brief)
+
+// Wall bust (players smash through walls and take a speed penalty)
+export const WALL_BUST_PENALTY_DURATION = 0.6;
+export const WALL_BUST_PENALTY_SPEED = 0.55;
+
 export const NETWORK_TICK_RATE = 0.033;
 export const ROOM_CODE_LENGTH = 5;
 export const COUNTDOWN_SECONDS = 3;
@@ -21,7 +33,15 @@ export const OBSTACLE_START_Z = 16;
 export const FINISH_GRACE_SECONDS = 10;
 export const NAME_MAX = 14;
 
-export type PropStyle = "antenna" | "crystal" | "ring" | "pillar";
+export type PropStyle = "antenna" | "crystal" | "ring" | "pillar" | "monolith" | "spire";
+export type ThemeStyle =
+  | "neon-city"
+  | "magenta-storm"
+  | "emerald-grid"
+  | "violet-void"
+  | "solar-flare"
+  | "deep-ocean"
+  | "volcanic";
 
 export interface TrackVariant {
   id: string;
@@ -51,6 +71,10 @@ export interface TrackVariant {
   // Occasional overhead gates.
   archStride: number;
   archColor: number;
+  // Theme selector for environment rendering (skyline, colour palette, ground tiles).
+  theme: ThemeStyle;
+  // Extra accent colour used by a few themes (e.g. rim lights, particle tints).
+  glowColor: number;
 }
 
 export const TRACK_VARIANTS: readonly TrackVariant[] = [
@@ -79,6 +103,8 @@ export const TRACK_VARIANTS: readonly TrackVariant[] = [
     propOffset: 2.5,
     archStride: 60,
     archColor: 0x79f3ff,
+    theme: "neon-city",
+    glowColor: 0x4fe3ff,
   },
   {
     id: "static-storm",
@@ -105,6 +131,8 @@ export const TRACK_VARIANTS: readonly TrackVariant[] = [
     propOffset: 2.2,
     archStride: 42,
     archColor: 0xff4fa0,
+    theme: "magenta-storm",
+    glowColor: 0xff4fa0,
   },
   {
     id: "amp-grid",
@@ -131,6 +159,8 @@ export const TRACK_VARIANTS: readonly TrackVariant[] = [
     propOffset: 2.8,
     archStride: 48,
     archColor: 0x8dff9d,
+    theme: "emerald-grid",
+    glowColor: 0x6df0a0,
   },
   {
     id: "long-haul",
@@ -157,6 +187,92 @@ export const TRACK_VARIANTS: readonly TrackVariant[] = [
     propOffset: 3.2,
     archStride: 72,
     archColor: 0xba7cff,
+    theme: "violet-void",
+    glowColor: 0xa065ff,
+  },
+  {
+    id: "solar-flare",
+    name: "SOLAR FLARE",
+    description: "Blazing corridor. Tight amp bursts under a molten sky.",
+    trackLength: 220,
+    obstacleStride: 5,
+    ampRatio: 0.42,
+    maxLanesOccupied: 3,
+    trackColor: 0x240a00,
+    railColor: 0xffc36b,
+    accentColor: 0x5a1f10,
+    fogColor: 0x1a0404,
+    fogNear: 50,
+    fogFar: 240,
+    curveAmplitude: 6,
+    curveFrequency: 0.03,
+    curvePhase: 0.2,
+    curveAmplitude2: 2.5,
+    curveFrequency2: 0.08,
+    propStyle: "spire",
+    propColor: 0xffa04f,
+    propStride: 10,
+    propOffset: 2.6,
+    archStride: 50,
+    archColor: 0xffc36b,
+    theme: "solar-flare",
+    glowColor: 0xff6a2a,
+  },
+  {
+    id: "deep-signal",
+    name: "DEEP SIGNAL",
+    description: "Abyssal band. Long glides between walls of static.",
+    trackLength: 280,
+    obstacleStride: 6.4,
+    ampRatio: 0.22,
+    maxLanesOccupied: 3,
+    trackColor: 0x04182a,
+    railColor: 0x4fc0ff,
+    accentColor: 0x0d304a,
+    fogColor: 0x020a14,
+    fogNear: 45,
+    fogFar: 260,
+    curveAmplitude: 8,
+    curveFrequency: 0.018,
+    curvePhase: 1.8,
+    curveAmplitude2: 3,
+    curveFrequency2: 0.045,
+    propStyle: "monolith",
+    propColor: 0x4fc0ff,
+    propStride: 16,
+    propOffset: 3.0,
+    archStride: 64,
+    archColor: 0x4fc0ff,
+    theme: "deep-ocean",
+    glowColor: 0x2890d0,
+  },
+  {
+    id: "magma-pulse",
+    name: "MAGMA PULSE",
+    description: "Volcanic relay. Crushing wall density, rare amps.",
+    trackLength: 250,
+    obstacleStride: 4,
+    ampRatio: 0.12,
+    maxLanesOccupied: 4,
+    trackColor: 0x1a0606,
+    railColor: 0xff5a3a,
+    accentColor: 0x4a0e0a,
+    fogColor: 0x100303,
+    fogNear: 35,
+    fogFar: 200,
+    curveAmplitude: 9,
+    curveFrequency: 0.035,
+    curvePhase: 0.7,
+    curveAmplitude2: 3,
+    curveFrequency2: 0.09,
+    propStyle: "spire",
+    propColor: 0xff5a3a,
+    propStride: 9,
+    propOffset: 2.4,
+    archStride: 40,
+    archColor: 0xff3a1a,
+    theme: "volcanic",
+    glowColor: 0xff7a2a,
   },
 ];
 
@@ -197,6 +313,21 @@ export interface Obstacle {
   kind: ObstacleKind;
   lane: number;
   z: number;
+  /** Walls (noise) are destructible. Amps are always alive. Host-authoritative. */
+  alive: boolean;
+}
+
+export interface LaserBeam {
+  /** Slot of the firing player. */
+  slot: number;
+  /** z coordinate at the shooter's nose when fired. */
+  fromZ: number;
+  /** z coordinate of the farthest point the beam reached (hit or max range). */
+  toZ: number;
+  /** Lane the beam travels in. */
+  lane: number;
+  /** Host time when the beam was fired. */
+  firedAt: number;
 }
 
 export interface PlayerSnap {
@@ -210,6 +341,8 @@ export interface PlayerSnap {
   boostUntil: number;
   burstUntil: number;
   burstsLeft: number;
+  /** 0..1 laser charge, 1 = ready. */
+  laserCharge: number;
   finished: boolean;
   finishTime: number | null;
 }
@@ -221,6 +354,7 @@ export interface GameSnapshot {
   countdown: number;
   players: PlayerSnap[];
   obstacles: Obstacle[];
+  beams: LaserBeam[];
   trackLength: number;
   laneCount: number;
   trackId: string;

--- a/src/routes/games/signal-surge/+page.svelte
+++ b/src/routes/games/signal-surge/+page.svelte
@@ -235,6 +235,12 @@
       <div class="chip">PLACE <b>{gs.hudPlace}/{gs.hudTotal}</b></div>
       <div class="chip">PROGRESS <b>{gs.hudProgress}%</b></div>
       <div class="chip">BURSTS <b>{gs.hudBursts}</b></div>
+      <div class="chip laser" class:ready={gs.hudLaser >= 1}>
+        LASER
+        <span class="bar" aria-hidden="true">
+          <span class="fill" style:width={`${Math.round(gs.hudLaser * 100)}%`}></span>
+        </span>
+      </div>
       {#if gs.cupTotalTracks > 0}
         <div class="chip">
           TRACK <b>{gs.cupTrackIndex + 1}/{gs.cupTotalTracks}</b>
@@ -249,6 +255,7 @@
       <span><kbd>←</kbd>/<kbd>A</kbd></span>
       <span><kbd>→</kbd>/<kbd>D</kbd></span>
       <span><kbd>SPACE</kbd> burst</span>
+      <span><kbd>F</kbd>/<kbd>SHIFT</kbd> laser</span>
     </div>
 
     <div class="log-panel" role="log" aria-live="polite">

--- a/src/routes/games/signal-surge/style.css
+++ b/src/routes/games/signal-surge/style.css
@@ -255,6 +255,36 @@
     color: var(--hot);
     border-color: var(--hot);
   }
+  .chip.laser {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .chip.laser .bar {
+    display: inline-block;
+    position: relative;
+    width: 56px;
+    height: 6px;
+    border: 1px solid #32456d;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+  }
+  .chip.laser .fill {
+    display: block;
+    height: 100%;
+    background: var(--hot);
+    transition: width 120ms linear;
+  }
+  .chip.laser.ready {
+    color: var(--hot);
+    border-color: var(--hot);
+    box-shadow: 0 0 12px rgba(255, 124, 207, 0.45);
+  }
+  .chip.laser.ready .fill {
+    background: var(--hot);
+    box-shadow: 0 0 8px var(--hot);
+  }
 
   .controls-hint {
     position: absolute;


### PR DESCRIPTION
Closes #53.

## Summary
- **Sync**: added `alive` flag on obstacles, plus per-player `laserCharge` and `LaserBeam[]` in snapshots, so clients no longer render entities the host considers destroyed (root cause: per-player `consumed` was host-local and missing from snapshots).
- **Controls**: flipped left/right lane mapping — chase camera at `z < 0` looking toward +z mirrors world-X on screen, so right arrow must now decrement lane.
- **More tracks**: appended SOLAR FLARE, DEEP SIGNAL, MAGMA PULSE (seven tracks total).
- **Catch-up laser**: new `fireLaser` action (F/Shift), recharge scales with place (trailers recharge faster), slows first opponent in lane and breaks every wall in the path; broadcast via snapshot.
- **Wall destruction**: contact with a noise wall sets `obs.alive = false` and applies a short `wallBustUntil` slow (instead of the old indefinite slow).
- **Visual themes**: `theme` + `glowColor` per variant, ambient tint, per-theme skyline silhouettes from seeded RNG, two new prop silhouettes (`monolith`, `spire`).
- **Boost visuals**: bigger exhaust cone + burst scaling, 5-puff particle trail, speed-line streaks, pulsing emissive ship, brighter point-light halo, brief camera shake on boost rising edge, HUD laser-charge meter.

## Test plan
- [ ] Host + join a race; verify no ghost walls/amps on the client after host destroys them.
- [ ] Left arrow steers visually left; right visually right.
- [ ] Cycle through all 7 track variants visually.
- [ ] Fall behind; confirm laser recharges faster and hits slow the leader.
- [ ] Ram a wall; wall destroyed and brief speed penalty applied.
- [ ] Activate boost; confirm particles, speed lines, and camera shake fire.