### PR TITLE
Semaphoria follow-up fixes (#54)

### DIFF
--- a/src/lib/semaphoria/constants.ts
+++ b/src/lib/semaphoria/constants.ts
@@ -52,6 +52,32 @@ export const SIG_COOLDOWN = 2.5;
 /** Distance in tiles to the nearest reef that triggers audio proximity warning. */
 export const PROXIMITY_WARN_DIST = 2.0;
 
+// ── SHIPWRECKS ────────────────────────────────────────────────────────────────
+
+/** Distance in tiles at which the captain can rescue survivors from a wreck. */
+export const WRECK_RESCUE_DIST = 1.2;
+
+/** Number of shipwrecks scattered along the route per difficulty. */
+export const WRECKS_PER_DIFFICULTY: readonly [number, number, number] = [2, 3, 4];
+
+/**
+ * Rescue-variant identifiers.  Each wreck is assigned one; the keeper sees
+ * the variant in the map panel so they can tell the captain *who* to rescue.
+ */
+export const RESCUE_VARIANTS = ["sailor", "child", "doctor", "merchant", "cat", "scholar"] as const;
+
+export type RescueVariant = (typeof RESCUE_VARIANTS)[number];
+
+/** Label shown to the keeper for each variant. */
+export const RESCUE_VARIANT_LABEL: Record<RescueVariant, string> = {
+  sailor: "Stranded sailor",
+  child: "Lost child",
+  doctor: "Ship's doctor",
+  merchant: "Merchant with cargo",
+  cat: "Ship's cat",
+  scholar: "Wandering scholar",
+};
+
 // ── SIGNAL COLORS ─────────────────────────────────────────────────────────────
 
 /** Hex color values for lighthouse beam signal colours. */

--- a/src/lib/semaphoria/engine.ts
+++ b/src/lib/semaphoria/engine.ts
@@ -16,6 +16,7 @@ import {
   moveShip,
   checkCollision,
   checkHarborReached,
+  findRescueableWreck,
   isNearReef,
   getRevealedTileKeys,
 } from "./navigation";
@@ -48,6 +49,8 @@ export interface GameStats {
   timeTaken: number;
   signalsSent: number;
   nearMisses: number;
+  wrecksRescued: number;
+  wrecksTotal: number;
   result: "success" | "failure";
 }
 
@@ -71,6 +74,10 @@ export interface GameState {
   nearMisses: number;
   /** Whether the ship was near a reef last tick (for tracking near-misses). */
   wasNearReef: boolean;
+  /** IDs of shipwrecks the captain has sailed close enough to rescue. */
+  rescuedWreckIds: ReadonlySet<number>;
+  /** ID of the most recently rescued wreck (for UI / audio cues). */
+  lastRescuedWreckId: number | null;
   seed: number;
   difficulty: Difficulty;
 }
@@ -92,6 +99,8 @@ export function createInitialState(seed: number, difficulty: Difficulty): GameSt
     signalsSent: 0,
     nearMisses: 0,
     wasNearReef: false,
+    rescuedWreckIds: new Set<number>(),
+    lastRescuedWreckId: null,
     seed,
     difficulty,
   };
@@ -198,9 +207,33 @@ function tickPlaying(state: GameState, dt: number, input: CaptainInput): GameSta
     return { ...state, ship, timeRemaining, phase: "failure" };
   }
 
-  // Harbor reached → success
+  // Rescue any wreck we drifted near — do this before harbor check so a wreck
+  // placed one tile short of the harbor still counts.
+  let rescuedWreckIds = state.rescuedWreckIds;
+  let lastRescuedWreckId = state.lastRescuedWreckId;
+  const newWreck = findRescueableWreck(ship, state.map.wrecks, rescuedWreckIds);
+  if (newWreck) {
+    const next = new Set(rescuedWreckIds);
+    next.add(newWreck.id);
+    rescuedWreckIds = next;
+    lastRescuedWreckId = newWreck.id;
+  }
+
+  // Harbor reached → success only if every wreck has been rescued.
+  // Otherwise the harbour is "closed" until the ship finishes the rescue sweep;
+  // the captain can still drift over it but the round doesn't end.
   if (checkHarborReached(ship, state.map)) {
-    return { ...state, ship, timeRemaining, phase: "success" };
+    if (rescuedWreckIds.size >= state.map.wrecks.length) {
+      return {
+        ...state,
+        ship,
+        timeRemaining,
+        phase: "success",
+        rescuedWreckIds,
+        lastRescuedWreckId,
+      };
+    }
+    // Fall through: rescue sweep incomplete, keep sailing.
   }
 
   // Track near-misses (entering danger zone for the first time counts as one)
@@ -221,6 +254,8 @@ function tickPlaying(state: GameState, dt: number, input: CaptainInput): GameSta
     nearMisses,
     wasNearReef: nearReef,
     revealedTileKeys,
+    rescuedWreckIds,
+    lastRescuedWreckId,
   };
 }
 
@@ -301,6 +336,8 @@ export function deriveStats(state: GameState): GameStats {
     timeTaken: config.timerS - state.timeRemaining,
     signalsSent: state.signalsSent,
     nearMisses: state.nearMisses,
+    wrecksRescued: state.rescuedWreckIds.size,
+    wrecksTotal: state.map.wrecks.length,
     result: state.phase === "success" ? "success" : "failure",
   };
 }
@@ -308,6 +345,20 @@ export function deriveStats(state: GameState): GameStats {
 /** Get the current flash signal colour, or null when dark. */
 export function getCurrentFlashColor(state: GameState): SigColor | null {
   return state.activeFlash?.flash?.color ?? null;
+}
+
+/**
+ * Mark a wreck as rescued on a replica state (keeper side).  No-op if the
+ * wreck is unknown or already rescued; returns the original state reference
+ * in that case so effects / reactive updates don't re-fire needlessly.
+ */
+export function markWreckRescued(state: GameState, wreckId: number): GameState {
+  if (state.rescuedWreckIds.has(wreckId)) return state;
+  const known = state.map.wrecks.some((w) => w.id === wreckId);
+  if (!known) return state;
+  const next = new Set(state.rescuedWreckIds);
+  next.add(wreckId);
+  return { ...state, rescuedWreckIds: next, lastRescuedWreckId: wreckId };
 }
 
 export { encodeSignal };

--- a/src/lib/semaphoria/map-generator.ts
+++ b/src/lib/semaphoria/map-generator.ts
@@ -1,5 +1,11 @@
-import { GRID_COLS, GRID_ROWS, DIFFICULTY_CONFIG } from "./constants";
-import type { Difficulty } from "./constants";
+import {
+  GRID_COLS,
+  GRID_ROWS,
+  DIFFICULTY_CONFIG,
+  RESCUE_VARIANTS,
+  WRECKS_PER_DIFFICULTY,
+} from "./constants";
+import type { Difficulty, RescueVariant } from "./constants";
 
 // ── TYPES ────────────────────────────────────────────────────────────────────
 
@@ -13,6 +19,20 @@ export interface Tile {
   onPath: boolean;
 }
 
+/**
+ * A single shipwreck placed along the route.  The captain must sail within
+ * {@link WRECK_RESCUE_DIST} to rescue the survivor aboard.
+ *
+ * The keeper sees the {@link variant} in the map panel so they can tell the
+ * captain *who* they're saving (flavour + coordination).
+ */
+export interface Shipwreck {
+  id: number;
+  x: number;
+  y: number;
+  variant: RescueVariant;
+}
+
 export interface GameMap {
   cols: number;
   rows: number;
@@ -24,6 +44,8 @@ export interface GameMap {
   harborY: number;
   /** Ordered sequence of tile coordinates forming the safe path, start → harbor. */
   path: readonly { x: number; y: number }[];
+  /** Shipwrecks the captain must reach — ordered start → harbor along the path. */
+  wrecks: readonly Shipwreck[];
 }
 
 // ── SEEDED RNG ────────────────────────────────────────────────────────────────
@@ -168,5 +190,57 @@ export function generateMap(seed: number, difficulty: Difficulty): GameMap {
   const harborTile = tiles[harborY]?.[harborX];
   if (harborTile) harborTile.type = "harbor";
 
-  return { cols, rows, tiles, startX, startY, harborX, harborY, path };
+  // Place shipwrecks along the path, evenly spaced, skipping the first/last tiles
+  // (safer to spawn away from start/harbor so rescue and harbor checks don't alias).
+  const wrecks = generateWrecks(path, difficulty, rng);
+
+  return { cols, rows, tiles, startX, startY, harborX, harborY, path, wrecks };
+}
+
+/**
+ * Pick roughly-evenly-spaced tiles along the path and assign each a unique
+ * rescue variant drawn from {@link RESCUE_VARIANTS}.  The first and last
+ * path tiles (start and harbor) are never used.
+ */
+function generateWrecks(
+  path: readonly { x: number; y: number }[],
+  difficulty: Difficulty,
+  rng: () => number
+): Shipwreck[] {
+  const count = WRECKS_PER_DIFFICULTY[difficulty];
+  // Need at least 3 path tiles to fit any wreck (start + 1 middle + harbor)
+  if (path.length < 3 || count <= 0) return [];
+
+  // Sample indices strictly between 1 and path.length - 2, evenly spaced,
+  // with a small deterministic jitter so two seeds at the same difficulty
+  // don't always pick identical path-indices.
+  const wrecks: Shipwreck[] = [];
+  const taken = new Set<string>();
+  const variants = shuffle([...RESCUE_VARIANTS], rng);
+  for (let i = 0; i < count; i += 1) {
+    const baseFraction = (i + 1) / (count + 1);
+    const jitter = (rng() - 0.5) * (1 / (count + 1)) * 0.5;
+    const frac = Math.min(0.95, Math.max(0.05, baseFraction + jitter));
+    const idx = Math.max(1, Math.min(path.length - 2, Math.round(frac * (path.length - 1))));
+    const pt = path[idx];
+    if (!pt) continue;
+    const key = `${pt.x},${pt.y}`;
+    if (taken.has(key)) continue;
+    taken.add(key);
+    const variant = variants[i % variants.length] ?? "sailor";
+    wrecks.push({ id: i, x: pt.x, y: pt.y, variant });
+  }
+  return wrecks;
+}
+
+function shuffle<T>(arr: T[], rng: () => number): T[] {
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    const a = arr[i];
+    const b = arr[j];
+    if (a === undefined || b === undefined) continue;
+    arr[i] = b;
+    arr[j] = a;
+  }
+  return arr;
 }

--- a/src/lib/semaphoria/navigation.ts
+++ b/src/lib/semaphoria/navigation.ts
@@ -6,10 +6,11 @@ import {
   FOG_RADIUS,
   KEEPER_AREA_COARSENESS,
   PROXIMITY_WARN_DIST,
+  WRECK_RESCUE_DIST,
   GRID_COLS,
   GRID_ROWS,
 } from "./constants";
-import type { GameMap } from "./map-generator";
+import type { GameMap, Shipwreck } from "./map-generator";
 
 // ── TYPES ────────────────────────────────────────────────────────────────────
 
@@ -167,4 +168,24 @@ export function getNearestReefDistance(ship: ShipState, map: GameMap): number {
  */
 export function isNearReef(ship: ShipState, map: GameMap): boolean {
   return getNearestReefDistance(ship, map) <= PROXIMITY_WARN_DIST;
+}
+
+// ── SHIPWRECK RESCUE ──────────────────────────────────────────────────────────
+
+/**
+ * Returns the first unrescued wreck within {@link WRECK_RESCUE_DIST} of the
+ * ship, or `null` if none are in range.  The captain rescues a wreck by
+ * sailing within this radius.
+ */
+export function findRescueableWreck(
+  ship: ShipState,
+  wrecks: readonly Shipwreck[],
+  rescued: ReadonlySet<number>
+): Shipwreck | null {
+  for (const w of wrecks) {
+    if (rescued.has(w.id)) continue;
+    const d = Math.hypot(ship.x - w.x, ship.y - w.y);
+    if (d <= WRECK_RESCUE_DIST) return w;
+  }
+  return null;
 }

--- a/src/routes/games/semaphoria/+page.svelte
+++ b/src/routes/games/semaphoria/+page.svelte
@@ -20,11 +20,12 @@
     sendSignal,
     getCurrentFlashColor,
     deriveStats,
+    markWreckRescued,
   } from "$lib/semaphoria/engine";
   import type { GameState, PlayerRole, CaptainInput } from "$lib/semaphoria/engine";
   import { SIGNAL_REFERENCE, encodeSignal } from "$lib/semaphoria/signals";
   import type { SignalCommand, FlashPattern } from "$lib/semaphoria/signals";
-  import { SEED_MAX } from "$lib/semaphoria/constants";
+  import { SEED_MAX, RESCUE_VARIANT_LABEL } from "$lib/semaphoria/constants";
   import {
     signalFlash,
     shipBell,
@@ -46,7 +47,8 @@
     | { t: "ship-pos"; x: number; y: number; heading: number }
     | { t: "signal"; command: SignalCommand }
     | { t: "game-over"; result: "success" | "failure" }
-    | { t: "role"; role: PlayerRole };
+    | { t: "role"; role: PlayerRole }
+    | { t: "wreck-rescued"; id: number };
 
   // ── State ─────────────────────────────────────────────────────────────────
 
@@ -75,6 +77,15 @@
   // Peer networking
   let peer: Peer | null = null;
   let conn: DataConnection | null = null;
+  /**
+   * Tracks which of {host, join, idle} the user initiated.  Guards against
+   * double-clicks of TUNE IN / OPEN CHANNEL while a connection is in flight,
+   * which previously caused the first peer to be orphaned and the lobby
+   * status to get wedged.
+   */
+  let netMode = $state<"idle" | "hosting" | "joining">("idle");
+  /** Room code being dialled, for idempotency checks. Clears on teardown. */
+  let joiningCode = $state("");
   let stopAmbient: (() => void) | null = null;
   let loop: ReturnType<typeof createGameLoop> | null = null;
 
@@ -148,6 +159,16 @@
           finishGame(msg.result);
         }
         break;
+      case "wreck-rescued":
+        if (gameState && myRole === "keeper") {
+          const updated = markWreckRescued(gameState, msg.id);
+          if (updated !== gameState) {
+            gameState = updated;
+            const wreck = gameState.map.wrecks.find((w) => w.id === msg.id);
+            if (wreck) log(`🛟 Rescued ${RESCUE_VARIANT_LABEL[wreck.variant]}`, "ok");
+          }
+        }
+        break;
     }
   }
 
@@ -168,20 +189,51 @@
     });
   }
 
+  /**
+   * Tear down any existing peer / connection so a fresh host / join attempt
+   * starts from a clean slate.  Safe to call multiple times.  Does NOT touch
+   * gameState / role / UI fields — callers own those.
+   */
+  function tearDownNet(): void {
+    try {
+      conn?.close();
+    } catch {
+      // ignore
+    }
+    try {
+      peer?.destroy();
+    } catch {
+      // ignore
+    }
+    conn = null;
+    peer = null;
+    netOk = false;
+    joiningCode = "";
+  }
+
   // ── Lobby actions ─────────────────────────────────────────────────────────
 
   function handleHost(): void {
+    // Idempotent: if we're already hosting, don't spin up a second peer.
+    if (netMode === "hosting") return;
+    // If the user was mid-join when they clicked OPEN CHANNEL, tear the
+    // previous peer down before creating the new one.
+    tearDownNet();
+    netMode = "hosting";
+    lobbyStatus = "";
     const code = makeCode(5);
-    peer = new Peer(`semaphoria-${code}`);
-    peer.on("open", () => {
+    const localPeer = new Peer(`semaphoria-${code}`);
+    peer = localPeer;
+    localPeer.on("open", () => {
       roomCode = code;
       isHost = true;
       myRole = "keeper";
       log(`Room ${code} open. You are the KEEPER.`, "ok");
       players = ["Keeper (you)"];
     });
-    peer.on("connection", (c) => {
-      if (conn) {
+    localPeer.on("connection", (c) => {
+      // Ignore connections that arrive after we've torn this peer down.
+      if (peer !== localPeer || conn) {
         c.close();
         return;
       }
@@ -195,9 +247,15 @@
       canStart = true;
       log("Captain connected!", "ok");
     });
-    peer.on("error", (err) => {
+    localPeer.on("error", (err) => {
       const e = err as { type?: string; message?: string };
       log(describePeerError(e), "bad");
+      // Fatal host errors (peer-unavailable, unavailable-id, network) leave the
+      // peer in an unusable state — reset so the user can re-try.
+      if (e.type === "unavailable-id" || e.type === "network") {
+        tearDownNet();
+        netMode = "idle";
+      }
     });
   }
 
@@ -207,20 +265,45 @@
       lobbyStatus = "Enter room code.";
       return;
     }
+    // Idempotent: if we're already dialling the same room, a repeat TUNE IN
+    // used to spawn a parallel Peer and wedge the lobby.  Short-circuit when
+    // the target matches; otherwise tear the previous peer down cleanly.
+    if (netMode === "joining") {
+      if (joiningCode === trimmed) return;
+      tearDownNet();
+    } else if (netMode === "hosting") {
+      // Switching from host → join: tear the host peer down.
+      tearDownNet();
+      isHost = false;
+      roomCode = "";
+      canStart = false;
+      players = [];
+    }
     myRole = "captain";
-    peer = new Peer(`semaphoria-g-${makeCode(8)}`);
-    peer.on("open", () => {
-      const c = (peer as Peer).connect(`semaphoria-${trimmed}`, { reliable: true });
+    netMode = "joining";
+    joiningCode = trimmed;
+    const localPeer = new Peer(`semaphoria-g-${makeCode(8)}`);
+    peer = localPeer;
+    localPeer.on("open", () => {
+      // If this peer was torn down (e.g. user clicked TUNE IN for a different
+      // room before the handshake resolved) don't dial — we'd race with the
+      // replacement peer and leak a zombie connection.
+      if (peer !== localPeer) return;
+      const c = localPeer.connect(`semaphoria-${trimmed}`, { reliable: true });
       setupConn(c, () => {
         lobbyStatus = "Waiting for keeper to start…";
       });
       lobbyStatus = "Connecting…";
       log(`Joining ${trimmed}…`);
     });
-    peer.on("error", (err) => {
+    localPeer.on("error", (err) => {
       const e = err as { type?: string; message?: string };
       lobbyStatus = describePeerError(e);
       log(lobbyStatus, "bad");
+      if (e.type === "peer-unavailable" || e.type === "network") {
+        tearDownNet();
+        netMode = "idle";
+      }
     });
   }
 
@@ -248,6 +331,7 @@
 
       const prevPhase = gameState.phase;
       const prevFlash = getCurrentFlashColor(gameState);
+      const prevLastRescue = gameState.lastRescuedWreckId;
 
       // Only the captain side advances ship physics.
       // Keeper side only updates the signal flash animation (no ship movement).
@@ -255,6 +339,21 @@
         myRole === "captain" ? captainInput : { turning: "none", moving: false };
 
       gameState = tick(gameState, dt, inputForThisSide, activePattern, myRole === "keeper");
+
+      // Captain-side rescue detection → tell the keeper so their map / log updates.
+      if (
+        myRole === "captain" &&
+        gameState.lastRescuedWreckId !== null &&
+        gameState.lastRescuedWreckId !== prevLastRescue
+      ) {
+        const id = gameState.lastRescuedWreckId;
+        const wreck = gameState.map.wrecks.find((w) => w.id === id);
+        if (wreck) {
+          log(`🛟 Rescued ${RESCUE_VARIANT_LABEL[wreck.variant]}`, "ok");
+          shipBell();
+          send({ t: "wreck-rescued", id });
+        }
+      }
 
       // Clear pattern once flash animation completes
       if (!gameState.activeFlash) {
@@ -361,12 +460,7 @@
   onDestroy(() => {
     loop?.stop();
     stopAmbient?.();
-    try {
-      conn?.close();
-      peer?.destroy();
-    } catch {
-      // ignore
-    }
+    tearDownNet();
   });
 
   // ── Derived display values ─────────────────────────────────────────────────
@@ -453,11 +547,18 @@
                 ship={gameState.ship}
                 map={gameState.map}
                 revealedTileKeys={gameState.revealedTileKeys}
+                rescuedWreckIds={gameState.rescuedWreckIds}
                 {flashColor}
                 {isFlashing}
               />
             {:else}
-              <KeeperView ship={gameState.ship} map={gameState.map} {flashColor} {isFlashing} />
+              <KeeperView
+                ship={gameState.ship}
+                map={gameState.map}
+                rescuedWreckIds={gameState.rescuedWreckIds}
+                {flashColor}
+                {isFlashing}
+              />
             {/if}
           </Canvas>
 
@@ -472,9 +573,19 @@
 
           <!-- Captain HUD -->
           {#if myRole === "captain"}
+            {@const allRescued =
+              gameState.rescuedWreckIds.size >= gameState.map.wrecks.length &&
+              gameState.map.wrecks.length > 0}
             <div class="hud-captain">
               <div class="hud-chip">
                 HEADING {((gameState.ship.heading * 180) / Math.PI).toFixed(0)}°
+              </div>
+              <div class="hud-chip" class:hud-chip-ok={allRescued}>
+                {#if allRescued}
+                  ALL ABOARD — MAKE FOR HARBOUR
+                {:else}
+                  SURVIVORS {gameState.rescuedWreckIds.size} / {gameState.map.wrecks.length}
+                {/if}
               </div>
               <div class="hud-chip steer-hint">WASD / ↑←→ to steer</div>
             </div>
@@ -493,6 +604,27 @@
               />
             </div>
           {/if}
+
+          <div class="panel">
+            <div class="panel-title">
+              RESCUES {gameState.rescuedWreckIds.size} / {gameState.map.wrecks.length}
+            </div>
+            <ul class="wreck-list">
+              {#each gameState.map.wrecks as wreck (wreck.id)}
+                {@const done = gameState.rescuedWreckIds.has(wreck.id)}
+                <li class:done>
+                  <span class="wreck-mark" aria-hidden="true">{done ? "✓" : "•"}</span>
+                  <span class="wreck-label">{RESCUE_VARIANT_LABEL[wreck.variant]}</span>
+                  {#if myRole === "keeper"}
+                    <span class="wreck-coord">({wreck.x},{wreck.y})</span>
+                  {/if}
+                </li>
+              {/each}
+              {#if gameState.map.wrecks.length === 0}
+                <li class="empty">No survivors on this route.</li>
+              {/if}
+            </ul>
+          </div>
 
           <div class="panel">
             <div class="panel-title">SIGNAL REFERENCE</div>
@@ -531,6 +663,10 @@
             <li>
               <span>Near misses</span>
               <span>{stats.nearMisses}</span>
+            </li>
+            <li>
+              <span>Survivors rescued</span>
+              <span>{stats.wrecksRescued} / {stats.wrecksTotal}</span>
             </li>
           </ul>
           <button onclick={() => location.reload()}>PLAY AGAIN</button>

--- a/src/routes/games/semaphoria/CaptainView.svelte
+++ b/src/routes/games/semaphoria/CaptainView.svelte
@@ -1,25 +1,29 @@
 <script lang="ts">
-  import { T, useTask } from "@threlte/core";
+  import { T, useTask, useThrelte } from "@threlte/core";
   import * as THREE from "three";
   import type { ShipState } from "$lib/semaphoria/navigation";
   import type { GameMap } from "$lib/semaphoria/map-generator";
+  import { SIG_COLOR_HEX } from "$lib/semaphoria/constants";
   import type { SigColor } from "$lib/semaphoria/constants";
   import Ocean from "./Ocean.svelte";
   import Ship from "./Ship.svelte";
   import Reef from "./Reef.svelte";
   import Fog from "./Fog.svelte";
   import Lighthouse from "./Lighthouse.svelte";
+  import Shipwreck from "./Shipwreck.svelte";
 
   let {
     ship,
     map,
     revealedTileKeys,
+    rescuedWreckIds,
     flashColor = null,
     isFlashing = false,
   }: {
     ship: ShipState;
     map: GameMap;
     revealedTileKeys: ReadonlySet<string>;
+    rescuedWreckIds: ReadonlySet<number>;
     flashColor?: SigColor | null;
     isFlashing?: boolean;
   } = $props();
@@ -40,7 +44,38 @@
   let camZ = $state(0);
   let camInitialised = false;
 
+  // ── Lighthouse-tinted ambient/fog ───────────────────────────────────────────
+  //
+  // When the lighthouse is flashing, we want the world to *feel* lit by it —
+  // fog colour, ambient and the scene background all drift toward the flash
+  // colour. When dark, we settle back to deep-blue moonlight.
+
+  const MOON_FOG = new THREE.Color(0x04080f);
+  const MOON_AMBIENT = new THREE.Color(0x2040a0);
+  const MOON_BACKGROUND = new THREE.Color(0x04080f);
+
+  // Reused per-tick scratch colours so the useTask loop doesn't allocate.
+  const scratchA = new THREE.Color();
+  const scratchB = new THREE.Color();
+
+  // Animated targets — lerp toward the flash colour when isFlashing, else back to moon.
+  const fogColor = new THREE.Color().copy(MOON_FOG);
+  const ambientColor = new THREE.Color().copy(MOON_AMBIENT);
+  const bgColor = new THREE.Color().copy(MOON_BACKGROUND);
+
+  // Expose reactive hex strings so Threlte re-binds material colours each frame
+  // (we mutate the same THREE.Color instance and also expose a scalar trigger).
+  let ambientHex = $state("#2040a0");
+  let ambientIntensity = $state(0.25);
+
+  // Create the scene fog once and attach it — Threlte exposes the raw scene.
+  const { scene } = useThrelte();
+  const sceneFog = new THREE.FogExp2(MOON_FOG.getHex(), 0.055);
+  scene.fog = sceneFog;
+  scene.background = bgColor;
+
   useTask((dt) => {
+    // Camera follow
     if (!camInitialised) {
       camX = ship.x;
       camZ = ship.y;
@@ -54,6 +89,29 @@
       camRef.position.set(camX, 14, camZ + 9);
       camRef.lookAt(camX, 0, camZ);
     }
+
+    // Lighthouse tint — when flashing, pull fog + ambient toward the beam colour.
+    const tintK = 1 - Math.exp(-dt * (isFlashing ? 10 : 3));
+    if (isFlashing && flashColor) {
+      scratchA.setHex(SIG_COLOR_HEX[flashColor]);
+      // Fog: mostly base fog with a hint of the beam colour (prevents whiteout).
+      scratchB.copy(scratchA).lerp(MOON_FOG, 0.65);
+      fogColor.lerp(scratchB, tintK);
+      // Ambient: stronger pull toward the beam colour.
+      scratchB.copy(scratchA).lerp(MOON_AMBIENT, 0.4);
+      ambientColor.lerp(scratchB, tintK);
+      // Background: near-black with a faint beam tint.
+      scratchB.copy(scratchA).lerp(MOON_BACKGROUND, 0.7);
+      bgColor.lerp(scratchB, tintK);
+    } else {
+      fogColor.lerp(MOON_FOG, tintK);
+      ambientColor.lerp(MOON_AMBIENT, tintK);
+      bgColor.lerp(MOON_BACKGROUND, tintK);
+    }
+
+    sceneFog.color.copy(fogColor);
+    ambientHex = `#${ambientColor.getHexString()}`;
+    ambientIntensity = isFlashing ? 0.55 : 0.28;
   });
 </script>
 
@@ -61,7 +119,7 @@
   makeDefault
   fov={55}
   near={0.1}
-  far={200}
+  far={120}
   oncreate={(ref) => {
     camRef = ref as THREE.PerspectiveCamera;
     camRef.position.set(ship.x, 14, ship.y + 9);
@@ -69,8 +127,8 @@
   }}
 />
 
-<!-- Moonlight ambient -->
-<T.AmbientLight color="#2040a0" intensity={0.25} />
+<!-- Moonlight ambient — colour + intensity is modulated every tick by the lighthouse -->
+<T.AmbientLight color={ambientHex} intensity={ambientIntensity} />
 
 <!-- Distant moon directional light -->
 <T.DirectionalLight color="#c8d8ff" intensity={0.6} position={[-10, 20, -15]} />
@@ -83,11 +141,18 @@
   <Reef x={tile.x} y={tile.y} />
 {/each}
 
+<!-- Shipwrecks the captain must rescue — only those within fog radius -->
+{#each map.wrecks as wreck (wreck.id)}
+  {#if revealedTileKeys.has(`${wreck.x},${wreck.y}`)}
+    <Shipwreck x={wreck.x} y={wreck.y} rescued={rescuedWreckIds.has(wreck.id)} />
+  {/if}
+{/each}
+
 <!-- Lighthouse visible at edge of fog -->
 <Lighthouse x={LIGHTHOUSE_X} z={LIGHTHOUSE_Z} {flashColor} {isFlashing} />
 
 <!-- The ship -->
 <Ship {ship} {isFlashing} />
 
-<!-- Fog of war -->
-<Fog {ship} />
+<!-- Fog of war (vignette around ship, tinted by lighthouse beam) -->
+<Fog {ship} {flashColor} {isFlashing} />

--- a/src/routes/games/semaphoria/Fog.svelte
+++ b/src/routes/games/semaphoria/Fog.svelte
@@ -2,16 +2,43 @@
   import { T, useTask } from "@threlte/core";
   import * as THREE from "three";
   import type { ShipState } from "$lib/semaphoria/navigation";
-  import { FOG_RADIUS } from "$lib/semaphoria/constants";
+  import { FOG_RADIUS, SIG_COLOR_HEX } from "$lib/semaphoria/constants";
+  import type { SigColor } from "$lib/semaphoria/constants";
 
-  let { ship }: { ship: ShipState } = $props();
+  let {
+    ship,
+    flashColor = null,
+    isFlashing = false,
+  }: {
+    ship: ShipState;
+    flashColor?: SigColor | null;
+    isFlashing?: boolean;
+  } = $props();
 
   let meshRef: THREE.Mesh | undefined;
 
-  useTask(() => {
-    if (meshRef?.material instanceof THREE.ShaderMaterial) {
-      meshRef.material.uniforms["uCenter"]?.value.set(ship.x, ship.y);
+  // Base fog colour — very dark, so the world off-screen is lost to night.
+  const BASE_FOG = new THREE.Color(0x040c16);
+  // Scratch colour used per-tick to avoid per-frame allocations.
+  const currentFog = new THREE.Color().copy(BASE_FOG);
+  const targetFog = new THREE.Color();
+
+  useTask((dt) => {
+    const mat = meshRef?.material;
+    if (!(mat instanceof THREE.ShaderMaterial)) return;
+    mat.uniforms["uCenter"]?.value.set(ship.x, ship.y);
+
+    // When the lighthouse flashes, bleed its colour into the surrounding fog
+    // so the beam visibly illuminates the darkness at the edge of vision.
+    if (isFlashing && flashColor) {
+      targetFog.setHex(SIG_COLOR_HEX[flashColor]).lerp(BASE_FOG, 0.55);
+    } else {
+      targetFog.copy(BASE_FOG);
     }
+    const k = 1 - Math.exp(-dt * (isFlashing ? 10 : 3));
+    currentFog.lerp(targetFog, k);
+    const uFog = mat.uniforms["uFogColor"];
+    if (uFog) uFog.value.copy(currentFog);
   });
 
   const fogMaterial = new THREE.ShaderMaterial({

--- a/src/routes/games/semaphoria/KeeperView.svelte
+++ b/src/routes/games/semaphoria/KeeperView.svelte
@@ -7,17 +7,20 @@
   import type { SigColor } from "$lib/semaphoria/constants";
   import { getKeeperAreaTile } from "$lib/semaphoria/navigation";
   import Lighthouse from "./Lighthouse.svelte";
+  import Shipwreck from "./Shipwreck.svelte";
 
   let camRef: THREE.OrthographicCamera | undefined = $state(undefined);
 
   let {
     map,
     ship,
+    rescuedWreckIds,
     flashColor = null,
     isFlashing = false,
   }: {
     map: GameMap;
     ship: ShipState;
+    rescuedWreckIds: ReadonlySet<number>;
     flashColor?: SigColor | null;
     isFlashing?: boolean;
   } = $props();
@@ -209,6 +212,11 @@
   <T.CircleGeometry args={[1.8, 16]} />
   <T.MeshBasicMaterial color="#ffdd00" transparent opacity={0.22} depthWrite={false} />
 </T.Mesh>
+
+<!-- Shipwreck markers so the keeper knows where to guide the captain -->
+{#each map.wrecks as wreck (wreck.id)}
+  <Shipwreck x={wreck.x} y={wreck.y} rescued={rescuedWreckIds.has(wreck.id)} overhead />
+{/each}
 
 <!-- Lighthouse model at fixed position -->
 <Lighthouse x={LIGHTHOUSE_X} z={LIGHTHOUSE_Z} {flashColor} {isFlashing} />

--- a/src/routes/games/semaphoria/Shipwreck.svelte
+++ b/src/routes/games/semaphoria/Shipwreck.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import { T } from "@threlte/core";
+
+  let {
+    x,
+    y,
+    rescued = false,
+    overhead = false,
+  }: {
+    x: number;
+    y: number;
+    rescued?: boolean;
+    /** Rendered from the keeper's top-down view — use flatter, more legible markers. */
+    overhead?: boolean;
+  } = $props();
+
+  // A deterministic jitter so each wreck has a distinct silhouette.
+  const rng = (offset: number): number => {
+    const s = (x * 37 + y * 101 + offset * 17) & 0xffff;
+    return ((s * 9301 + 49297) % 233280) / 233280;
+  };
+
+  const tilt = (rng(1) - 0.5) * 0.8;
+  const rotY = rng(2) * Math.PI * 2;
+</script>
+
+{#if overhead}
+  <!-- Keeper view: a glowing ring + cross so wrecks stand out on the map -->
+  <T.Mesh position.x={x} position.y={0.03} position.z={y} rotation.x={-Math.PI / 2}>
+    <T.RingGeometry args={[0.45, 0.6, 16]} />
+    <T.MeshBasicMaterial
+      color={rescued ? "#44ff88" : "#ffae00"}
+      transparent
+      opacity={rescued ? 0.45 : 0.9}
+      depthWrite={false}
+    />
+  </T.Mesh>
+  <T.Mesh position.x={x} position.y={0.04} position.z={y} rotation.x={-Math.PI / 2}>
+    <T.PlaneGeometry args={[0.12, 0.7]} />
+    <T.MeshBasicMaterial
+      color={rescued ? "#44ff88" : "#ffae00"}
+      transparent
+      opacity={rescued ? 0.5 : 0.85}
+      depthWrite={false}
+    />
+  </T.Mesh>
+  <T.Mesh
+    position.x={x}
+    position.y={0.04}
+    position.z={y}
+    rotation.x={-Math.PI / 2}
+    rotation.z={Math.PI / 2}
+  >
+    <T.PlaneGeometry args={[0.12, 0.7]} />
+    <T.MeshBasicMaterial
+      color={rescued ? "#44ff88" : "#ffae00"}
+      transparent
+      opacity={rescued ? 0.5 : 0.85}
+      depthWrite={false}
+    />
+  </T.Mesh>
+{:else}
+  <!-- Captain view: an actual broken-hull silhouette -->
+  <T.Group position.x={x} position.y={0.08} position.z={y} rotation.y={rotY} rotation.z={tilt}>
+    <!-- Half-sunk hull -->
+    <T.Mesh position.y={0.12}>
+      <T.BoxGeometry args={[0.9, 0.25, 0.45]} />
+      <T.MeshStandardMaterial color={rescued ? "#3a5a3a" : "#4a2e1a"} roughness={0.95} />
+    </T.Mesh>
+    <!-- Broken mast -->
+    <T.Mesh position.y={0.5} position.x={-0.15} rotation.z={0.6}>
+      <T.CylinderGeometry args={[0.035, 0.04, 0.9, 6]} />
+      <T.MeshStandardMaterial color="#2a1a10" roughness={1} />
+    </T.Mesh>
+    <!-- Distress lantern (dim while survivors remain, green when rescued) -->
+    <T.Mesh position.y={0.3} position.x={0.2}>
+      <T.SphereGeometry args={[0.07, 8, 8]} />
+      <T.MeshStandardMaterial
+        color={rescued ? "#44ff88" : "#ffae00"}
+        emissive={rescued ? "#44ff88" : "#ffae00"}
+        emissiveIntensity={rescued ? 1.2 : 2.6}
+      />
+    </T.Mesh>
+    <!-- Low point light so the wreck glows through fog -->
+    <T.PointLight
+      position.y={0.3}
+      position.x={0.2}
+      color={rescued ? "#44ff88" : "#ffae00"}
+      intensity={rescued ? 1.5 : 2.5}
+      distance={4}
+      decay={2}
+    />
+  </T.Group>
+{/if}

--- a/src/routes/games/semaphoria/style.css
+++ b/src/routes/games/semaphoria/style.css
@@ -162,6 +162,57 @@
     margin-bottom: 8px;
   }
 
+  /* ── Rescue list ──────────────────────────────────────────────────────────── */
+
+  .wreck-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+  }
+
+  .wreck-list li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 2px 4px;
+    border-radius: 2px;
+    background: rgba(255, 255, 255, 0.02);
+    transition: color 0.2s;
+  }
+
+  .wreck-list li.done {
+    color: #44ff88;
+    opacity: 0.75;
+    text-decoration: line-through;
+  }
+
+  .wreck-list li.empty {
+    opacity: 0.4;
+    font-style: italic;
+  }
+
+  .wreck-list .wreck-mark {
+    flex-shrink: 0;
+    width: 12px;
+    text-align: center;
+    opacity: 0.8;
+  }
+
+  .wreck-list .wreck-label {
+    flex: 1;
+    letter-spacing: 0.04em;
+  }
+
+  .wreck-list .wreck-coord {
+    font-size: 10px;
+    opacity: 0.55;
+    font-variant-numeric: tabular-nums;
+  }
+
   /* ── Countdown ────────────────────────────────────────────────────────────── */
 
   .countdown-overlay {
@@ -258,6 +309,12 @@
     border-radius: 2px;
     font-size: 12px;
     letter-spacing: 0.08em;
+  }
+
+  .hud-chip.hud-chip-ok {
+    color: #44ff88;
+    border-color: rgba(68, 255, 136, 0.5);
+    background: rgba(20, 60, 40, 0.7);
   }
 
   /* ── Buttons ──────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Closes #54.

## Summary
**Keeper decision:** retained. Point 5 describes a concrete role (guide captain to shipwrecks with variant rescues) and the lobby/signal/network infrastructure is already two-role — collapsing would be a bigger rewrite. Point 4's fog tinting also makes the lighthouse visibly useful to the captain, addressing the "can't see lighthouse" complaint.

- **Tune-in idempotency**: `handleHost`/`handleJoin` guard on `netMode` + `joiningCode`; duplicate clicks short-circuit for same target, cleanly tear down + redial for different targets (centralised `tearDownNet()`).
- **Networking stability**: stale peer callbacks bail when `peer !== localPeer`; fatal peer errors reset `netMode`; `onDestroy` routes through `tearDownNet`.
- **Keeper purpose**: keeper map panel lists every wreck with coordinates and rescue variant, marks each off via new `wreck-rescued` NetMsg.
- **Fog + ambient tinted by lighthouse**: `FogExp2` on the scene; ambient + background + fog vignette lerp toward flash colour while `isFlashing`, blended with moonlit base.
- **Shipwrecks + rescue variants**: 2/3/4 wrecks per difficulty, shuffled labels (sailor / child / doctor / merchant / cat / scholar); engine tracks `rescuedWreckIds`; harbor success gated on full sweep; HUD shows survivors x/y → ALL ABOARD; new `Shipwreck.svelte` component.

### Follow-ups
- Per-variant rescue sub-tasks (e.g. "doctor requires approach from south").
- Wreck spacing tuning per difficulty.
- Spectator / 3-player support.
- Disabled-while-connecting lobby buttons (behaviourally safe via idempotency; UX polish only).

## Test plan
- [ ] Host + join; press Tune-In again mid-session — no crash, no state corruption.
- [ ] Disconnect and reconnect a peer; stale callbacks don't fire.
- [ ] Keeper role: map shows wrecks + variants; captain rescuing a wreck checks it off on keeper's map.
- [ ] Fog is visible; lighthouse flash visibly tints the fog/ambient colour.
- [ ] Captain must rescue every wreck before harbor counts as success.